### PR TITLE
feat: Fix loop with real advance function

### DIFF
--- a/src/lakeflow_migration_validator/harness/harness_runner.py
+++ b/src/lakeflow_migration_validator/harness/harness_runner.py
@@ -83,9 +83,11 @@ class HarnessRunner:
             snapshot, scorecard, fix_suggestions = self.fix_loop.iterate(snapshot, scorecard)
             iterations = len(fix_suggestions) + 1
         elif self.max_iterations > 1 and self.judge_provider is not None:
+            advance_fn = self._make_advance_fn(pipeline_json)
             loop = FixLoop(
                 judge_provider=self.judge_provider,
-                max_iterations=1,
+                max_iterations=self.max_iterations,
+                advance_fn=advance_fn,
             )
             snapshot, scorecard, fix_suggestions = loop.iterate(snapshot, scorecard)
             iterations = len(fix_suggestions) + 1
@@ -102,6 +104,22 @@ class HarnessRunner:
         """Run harness for explicit pipelines, or all pipelines from connector."""
         names = pipeline_names if pipeline_names is not None else self.adf_connector.list_pipelines()
         return [self.run(name) for name in names]
+
+    def _make_advance_fn(self, pipeline_json: dict):
+        """Build an advance callback that re-translates and re-evaluates."""
+
+        def _advance(
+            current_snapshot: ConversionSnapshot,
+            current_scorecard: Scorecard,
+            suggestion: dict,
+            iteration: int,
+        ) -> tuple[ConversionSnapshot, Scorecard]:
+            source_pipeline, prepared_workflow = self.adf_connector.translate_and_prepare(pipeline_json)
+            new_snapshot = self.wkmigrate_adapter(source_pipeline, prepared_workflow)
+            new_scorecard = self._evaluate_snapshot(new_snapshot)
+            return new_snapshot, new_scorecard
+
+        return _advance
 
     def _evaluate_snapshot(self, snapshot: ConversionSnapshot) -> Scorecard:
         if self.judge_provider is None:

--- a/tests/unit/validation/test_fix_loop.py
+++ b/tests/unit/validation/test_fix_loop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from lakeflow_migration_validator.dimensions import DimensionResult
 from lakeflow_migration_validator.harness.fix_loop import FixLoop
 from lakeflow_migration_validator.scorecard import Scorecard
-from tests.unit.validation.conftest import make_snapshot
+from tests.unit.validation.conftest import make_snapshot, make_task
 
 
 class _Provider:
@@ -79,3 +79,72 @@ def test_fix_loop_runs_multiple_iterations_with_advance_callback():
     assert len(calls) == 1
     assert len(suggestions) == 1
     assert updated_scorecard.score == 100.0
+
+
+def test_fix_loop_with_advance_fn_re_evaluates():
+    """advance_fn returns an improved snapshot; score increases each iteration."""
+    provider = _Provider()
+    scorecard = _make_scorecard()
+    snapshot = make_snapshot()
+    iteration_scores = []
+
+    def advance(_snapshot, _scorecard, suggestion, iteration):
+        # Each iteration improves the a_dim score, but never reaches all_passed
+        new_a_score = min(0.1 + 0.3 * iteration, 0.7)
+        improved = Scorecard(
+            weights=scorecard.weights,
+            results={
+                "a_dim": DimensionResult(name="a_dim", score=new_a_score, passed=False, details={}),
+                "z_dim": DimensionResult(name="z_dim", score=0.1, passed=False, details={}),
+                "b_dim": DimensionResult(name="b_dim", score=0.8, passed=True, details={}),
+            },
+            score=new_a_score * 100,
+        )
+        iteration_scores.append(new_a_score)
+        new_snapshot = make_snapshot(tasks=[make_task(f"task_iter_{iteration}")])
+        return new_snapshot, improved
+
+    loop = FixLoop(judge_provider=provider, max_iterations=3, advance_fn=advance)
+
+    updated_snapshot, updated_scorecard, suggestions = loop.iterate(snapshot, scorecard)
+
+    assert len(suggestions) == 3
+    assert len(iteration_scores) == 3
+    # Scores should increase across iterations
+    assert iteration_scores[0] < iteration_scores[1] <= iteration_scores[2]
+    # Final scorecard reflects the last advance_fn return
+    assert updated_scorecard.score == iteration_scores[-1] * 100
+    # Final snapshot is the one returned by the last advance_fn call
+    assert updated_snapshot.tasks[0].task_key == "task_iter_3"
+
+
+def test_fix_loop_early_exit_on_all_passed():
+    """advance_fn returns a perfect snapshot on the first iteration; loop stops early."""
+    provider = _Provider()
+    scorecard = _make_scorecard()
+    snapshot = make_snapshot()
+    advance_calls = []
+
+    def advance(_snapshot, _scorecard, suggestion, iteration):
+        advance_calls.append(iteration)
+        perfect = Scorecard(
+            weights=scorecard.weights,
+            results={
+                "a_dim": DimensionResult(name="a_dim", score=1.0, passed=True, details={}),
+                "z_dim": DimensionResult(name="z_dim", score=1.0, passed=True, details={}),
+                "b_dim": DimensionResult(name="b_dim", score=1.0, passed=True, details={}),
+            },
+            score=100.0,
+        )
+        return make_snapshot(tasks=[make_task("perfect")]), perfect
+
+    loop = FixLoop(judge_provider=provider, max_iterations=5, advance_fn=advance)
+
+    updated_snapshot, updated_scorecard, suggestions = loop.iterate(snapshot, scorecard)
+
+    # Only one iteration should run because all_passed is True after first advance
+    assert len(suggestions) == 1
+    assert len(advance_calls) == 1
+    assert updated_scorecard.all_passed is True
+    assert updated_scorecard.score == 100.0
+    assert updated_snapshot.tasks[0].task_key == "perfect"

--- a/tests/unit/validation/test_harness_runner.py
+++ b/tests/unit/validation/test_harness_runner.py
@@ -125,3 +125,41 @@ def test_harness_run_with_fix_loop_integration():
 
     assert result.fix_suggestions
     assert result.iterations > 1
+
+
+def test_harness_runner_creates_advance_fn_with_max_iterations():
+    """When max_iterations > 1 and judge_provider is set, the harness wires an advance_fn
+    that re-translates and re-evaluates, enabling multiple fix-loop iterations."""
+    translate_calls = []
+    adapter_calls = []
+
+    class _TrackingConnector(_Connector):
+        def translate_and_prepare(self, pipeline_json: dict) -> tuple[dict, object]:
+            translate_calls.append(pipeline_json["name"])
+            return pipeline_json, {"prepared": pipeline_json["name"]}
+
+    class _Provider:
+        def judge(self, prompt: str, model: str | None = None):
+            return {"score": 0.5, "reasoning": "needs improvement"}
+
+    connector = _TrackingConnector()
+
+    def adapter(source_pipeline: dict, _prepared_workflow: object):
+        adapter_calls.append(source_pipeline["name"])
+        return make_snapshot(tasks=[make_task("a", is_placeholder=True)])
+
+    runner = HarnessRunner(
+        adf_connector=connector,
+        wkmigrate_adapter=adapter,
+        judge_provider=_Provider(),
+        max_iterations=3,
+    )
+
+    result = runner.run("pipe_a")
+
+    # Initial translate + one per advance iteration (max_iterations=3 means up to 3 suggestions,
+    # each followed by an advance call except possibly the last if loop completes)
+    assert len(translate_calls) >= 2, f"Expected re-translation calls, got {len(translate_calls)}"
+    assert len(adapter_calls) >= 2, f"Expected re-adaptation calls, got {len(adapter_calls)}"
+    assert result.iterations > 1
+    assert len(result.fix_suggestions) == result.iterations - 1


### PR DESCRIPTION
## Summary
- **HarnessRunner** now creates a proper `advance_fn` when `max_iterations > 1` and `judge_provider` is set. The advance callback re-translates the pipeline via `adf_connector.translate_and_prepare()`, produces a new `ConversionSnapshot` through the `wkmigrate_adapter`, and re-evaluates it -- enabling the FixLoop to run multiple real iterations instead of breaking after the first suggestion.
- **FixLoop** `iterate()` already supported the advance/re-evaluate/early-exit pattern; this change wires it end-to-end from the harness.
- Added three new tests covering: score improvement across iterations, early exit on `all_passed`, and verification that the harness creates and wires the advance_fn when `max_iterations > 1`.

## Test plan
- [x] `test_fix_loop_with_advance_fn_re_evaluates` -- advance_fn returns progressively improved scorecards; asserts scores increase and final snapshot/scorecard match last iteration
- [x] `test_fix_loop_early_exit_on_all_passed` -- advance_fn returns perfect scorecard on first call; asserts loop stops after 1 iteration out of 5
- [x] `test_harness_runner_creates_advance_fn_with_max_iterations` -- tracking connector/adapter verify re-translation and re-adaptation calls happen across iterations
- [x] All 13 tests in `test_fix_loop.py` and `test_harness_runner.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes harness fix-loop control flow to perform repeated translate/adapt/evaluate cycles, which can affect runtime/cost and iteration outcomes when `max_iterations > 1`. Logic is localized but touches the main orchestration path for validation runs.
> 
> **Overview**
> **HarnessRunner now enables true multi-iteration fix loops.** When `max_iterations > 1` and a `judge_provider` is set, it builds and passes an `advance_fn` that re-runs `translate_and_prepare`, re-invokes the adapter, and re-evaluates the resulting `ConversionSnapshot` each iteration (instead of effectively stopping after the first suggestion).
> 
> **Tests expand coverage for iteration behavior.** New unit tests verify `FixLoop` re-evaluates across iterations, exits early on `all_passed`, and that `HarnessRunner` actually triggers re-translation/re-adaptation when running with multiple iterations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0af2236bb76234a3da8d8a930ee1963dafcc7ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->