### PR TITLE
feat: DSPy judge calibration with ManualCalibrator fallback

### DIFF
--- a/golden_sets/calibration_pairs.json
+++ b/golden_sets/calibration_pairs.json
@@ -1,0 +1,147 @@
+{
+  "description": "Human-labelled ADF expression / Python translation pairs for judge calibration. Scores range from 0.0 (completely wrong) to 1.0 (perfect semantic equivalence).",
+  "version": "1.0",
+  "count": 20,
+  "calibration_pairs": [
+    {
+      "adf_expression": "@concat('hello', 'world')",
+      "python_code": "str('hello') + str('world')",
+      "human_score": 1.0,
+      "category": "string",
+      "notes": "Perfect translation — concat maps to string concatenation with str() coercion."
+    },
+    {
+      "adf_expression": "@replace('abc', 'a', 'z')",
+      "python_code": "str('abc').replace('a', 'z')",
+      "human_score": 1.0,
+      "category": "string",
+      "notes": "Exact semantic match for single-character replacement."
+    },
+    {
+      "adf_expression": "@toUpper('abc')",
+      "python_code": "'abc'.upper()",
+      "human_score": 0.9,
+      "category": "string",
+      "notes": "Correct behaviour but missing str() wrapper — minor deviation from wkmigrate convention."
+    },
+    {
+      "adf_expression": "@concat('a', 'b', 'c')",
+      "python_code": "str('a') + str('b')",
+      "human_score": 0.3,
+      "category": "string",
+      "notes": "Missing third argument — concat('a','b','c') should produce 'abc', not 'ab'."
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "python_code": "(1 + 2)",
+      "human_score": 1.0,
+      "category": "math",
+      "notes": "Perfect — add(1,2) maps directly to (1 + 2)."
+    },
+    {
+      "adf_expression": "@add(mul(pipeline().parameters.count, 2), 1)",
+      "python_code": "(int(dbutils.widgets.get('count')) * 2 + 1)",
+      "human_score": 0.95,
+      "category": "math",
+      "notes": "Correct semantics with proper coercion from string widget. Minor: no outer parens for add."
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "python_code": "(9 / 2)",
+      "human_score": 0.5,
+      "category": "math",
+      "notes": "ADF div() returns integer division — Python / returns float. Should be int(9 / 2)."
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "python_code": "(9 % 2)",
+      "human_score": 1.0,
+      "category": "math",
+      "notes": "Perfect modulo mapping."
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "human_score": 1.0,
+      "category": "datetime",
+      "notes": "Correct delegation to wkmigrate helper with proper arguments."
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "python_code": "datetime.now()",
+      "human_score": 0.4,
+      "category": "datetime",
+      "notes": "Missing timezone — utcNow() must return UTC-aware datetime. datetime.now() returns local time."
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "python_code": "(1 == 1)",
+      "human_score": 1.0,
+      "category": "logical",
+      "notes": "Perfect — direct equality comparison."
+    },
+    {
+      "adf_expression": "@and(greater(pipeline().parameters.threshold, 50), not(equals(pipeline().parameters.env, 'prod')))",
+      "python_code": "(int(dbutils.widgets.get('threshold')) > 50 and not (dbutils.widgets.get('env') == 'prod'))",
+      "human_score": 0.85,
+      "category": "logical",
+      "notes": "Correct logic. Minor: threshold comparison should use > not >=, and env doesn't need int coercion (correct)."
+    },
+    {
+      "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+      "python_code": "('yes' if (1 == 1) else 'no')",
+      "human_score": 1.0,
+      "category": "logical",
+      "notes": "Perfect ternary mapping."
+    },
+    {
+      "adf_expression": "@if(greater(pipeline().parameters.x, 10), 'big', 'small')",
+      "python_code": "'big'",
+      "human_score": 0.1,
+      "category": "logical",
+      "notes": "Hardcoded result — completely ignores the conditional logic and parameter reference."
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "python_code": "len([1, 2, 3])",
+      "human_score": 1.0,
+      "category": "collection",
+      "notes": "Perfect — createArray maps to list literal, length maps to len()."
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)",
+      "human_score": 1.0,
+      "category": "collection",
+      "notes": "Correct coalesce implementation using generator expression."
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "python_code": "str(str('x').upper()) + str(str((1 + 2)))",
+      "human_score": 1.0,
+      "category": "nested",
+      "notes": "Correct nesting — toUpper inside concat, add inside string inside concat."
+    },
+    {
+      "adf_expression": "@concat(formatDateTime(utcNow(), 'yyyy-MM-dd'), '/', pipeline().parameters.env)",
+      "python_code": "str(_wkmigrate_format_datetime(_wkmigrate_utc_now(), 'yyyy-MM-dd')) + str('/') + str(dbutils.widgets.get('env'))",
+      "human_score": 0.95,
+      "category": "nested",
+      "notes": "Correct semantics with proper helper delegation. Minor: extra str() around '/' literal is unnecessary but harmless."
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "python_code": "str(len(str('a-b-c').split('-')))",
+      "human_score": 1.0,
+      "category": "nested",
+      "notes": "Perfect — split to .split(), length to len(), string to str()."
+    },
+    {
+      "adf_expression": "@concat(pipeline().parameters.prefix, '/', formatDateTime(utcNow(), 'yyyy/MM/dd'), '/data.csv')",
+      "python_code": "dbutils.widgets.get('prefix')",
+      "human_score": 0.0,
+      "category": "nested",
+      "notes": "Completely wrong — only emits the first parameter, drops the path construction, date formatting, and filename."
+    }
+  ]
+}

--- a/src/lakeflow_migration_validator/optimization/judge_optimizer.py
+++ b/src/lakeflow_migration_validator/optimization/judge_optimizer.py
@@ -1,0 +1,438 @@
+"""DSPy-based judge calibration with ManualCalibrator fallback.
+
+When DSPy 3.x is installed, ``JudgeOptimizer`` wraps the LLMJudge as a DSPy
+module and runs MIPROv2 or SIMBA optimisation against human-labelled
+calibration pairs.
+
+When DSPy is *not* installed (the common case during development),
+``ManualCalibrator`` provides a lightweight fallback that selects the best
+few-shot examples from a calibration set and produces an improved LLMJudge
+with a richer prompt template.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from lakeflow_migration_validator.dimensions.llm_judge import LLMJudge, JudgeProvider
+
+# ---------------------------------------------------------------------------
+# Calibration pair schema
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class CalibrationPair:
+    """A single human-labelled ADF-expression / Python-code pair."""
+
+    adf_expression: str
+    python_code: str
+    human_score: float
+    category: str = ""
+    notes: str = ""
+
+    def as_example_dict(self) -> dict[str, Any]:
+        return {
+            "input": self.adf_expression,
+            "output": self.python_code,
+            "score": self.human_score,
+        }
+
+
+def load_calibration_pairs(path: str | Path) -> list[CalibrationPair]:
+    """Load calibration pairs from a JSON file.
+
+    Expected schema::
+
+        {
+          "calibration_pairs": [
+            {
+              "adf_expression": "...",
+              "python_code": "...",
+              "human_score": 0.95,
+              "category": "string",
+              "notes": "optional"
+            },
+            ...
+          ]
+        }
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    pairs: list[CalibrationPair] = []
+    for item in data.get("calibration_pairs", []):
+        pairs.append(
+            CalibrationPair(
+                adf_expression=item["adf_expression"],
+                python_code=item["python_code"],
+                human_score=float(item["human_score"]),
+                category=item.get("category", ""),
+                notes=item.get("notes", ""),
+            )
+        )
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Improved prompt template used by the ManualCalibrator
+# ---------------------------------------------------------------------------
+
+_CALIBRATED_CRITERIA = (
+    "You are an expert judge for ADF-to-Python migration quality. "
+    "Evaluate whether the Python output preserves the EXACT semantics of the "
+    "original ADF expression. Pay careful attention to:\n"
+    "  1. Type coercion — ADF functions like concat() auto-coerce to string; "
+    "Python may need explicit str() calls.\n"
+    "  2. Edge cases — null handling, empty strings, division-by-zero guards.\n"
+    "  3. Function mapping — each ADF function must map to the correct Python "
+    "equivalent (e.g., @toUpper → .upper(), @indexOf → .find()).\n"
+    "  4. Nesting correctness — deeply nested expressions must preserve "
+    "evaluation order and parenthesisation.\n"
+    "  5. Parameter references — pipeline().parameters.X must map to the "
+    "corresponding dbutils.widgets.get('X') call with proper coercion.\n"
+    "\n"
+    "Score 1.0 = perfect semantic equivalence.\n"
+    "Score 0.7-0.9 = minor differences (e.g., extra whitespace, unnecessary "
+    "str() wrapping) that do not change runtime behaviour.\n"
+    "Score 0.3-0.6 = partial equivalence — some logic preserved, but at "
+    "least one semantic difference.\n"
+    "Score 0.0-0.2 = incorrect — the Python code does not reproduce the ADF "
+    "expression's behaviour."
+)
+
+_CALIBRATED_TEMPLATE = (
+    "=== ADF Expression ===\n{input}\n\n"
+    "=== Python Translation ===\n{output}\n\n"
+    "Evaluate semantic equivalence using the criteria above."
+)
+
+
+# ---------------------------------------------------------------------------
+# ManualCalibrator — no DSPy required
+# ---------------------------------------------------------------------------
+
+def _select_diverse_examples(
+    pairs: list[CalibrationPair],
+    max_examples: int = 10,
+) -> tuple[dict[str, Any], ...]:
+    """Select a diverse, informative subset of calibration examples.
+
+    Strategy:
+    - Always include at least one low-score example (< 0.5) so the judge
+      learns what *bad* translations look like.
+    - Always include at least one perfect example (1.0).
+    - Maximise category diversity.
+    - Prefer examples at the score boundaries (near 0.0, 0.5, 0.7, 1.0).
+    """
+    if not pairs:
+        return ()
+    if len(pairs) <= max_examples:
+        return tuple(p.as_example_dict() for p in pairs)
+
+    # Bucket by score range
+    buckets: dict[str, list[CalibrationPair]] = {
+        "perfect": [],
+        "good": [],
+        "partial": [],
+        "bad": [],
+    }
+    for p in pairs:
+        if p.human_score >= 0.95:
+            buckets["perfect"].append(p)
+        elif p.human_score >= 0.7:
+            buckets["good"].append(p)
+        elif p.human_score >= 0.4:
+            buckets["partial"].append(p)
+        else:
+            buckets["bad"].append(p)
+
+    selected: list[CalibrationPair] = []
+    seen_categories: set[str] = set()
+
+    # Guarantee at least one from each non-empty bucket
+    for bucket_name in ("perfect", "bad", "partial", "good"):
+        bucket = buckets[bucket_name]
+        if not bucket:
+            continue
+        # Prefer an unseen category
+        for p in bucket:
+            if p.category and p.category not in seen_categories:
+                selected.append(p)
+                seen_categories.add(p.category)
+                break
+        else:
+            selected.append(bucket[0])
+
+    # Fill remaining slots with category-diverse picks
+    remaining = [p for p in pairs if p not in selected]
+    remaining.sort(key=lambda p: (p.category in seen_categories, abs(p.human_score - 0.5)))
+    for p in remaining:
+        if len(selected) >= max_examples:
+            break
+        selected.append(p)
+        if p.category:
+            seen_categories.add(p.category)
+
+    # Sort by score descending so the judge sees perfect examples first
+    selected.sort(key=lambda p: -p.human_score)
+
+    return tuple(p.as_example_dict() for p in selected)
+
+
+class ManualCalibrator:
+    """Fallback calibrator that works without DSPy.
+
+    Loads human-labelled calibration pairs, selects a diverse subset as
+    few-shot examples, and returns an improved :class:`LLMJudge` with a
+    richer prompt template.
+    """
+
+    def __init__(
+        self,
+        calibration_pairs: list[CalibrationPair],
+        *,
+        max_examples: int = 10,
+    ) -> None:
+        self._pairs = list(calibration_pairs)
+        self._max_examples = max_examples
+        self._selected_examples: tuple[dict[str, Any], ...] | None = None
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        *,
+        max_examples: int = 10,
+    ) -> ManualCalibrator:
+        """Convenience constructor that loads pairs from a JSON file."""
+        pairs = load_calibration_pairs(path)
+        return cls(pairs, max_examples=max_examples)
+
+    @property
+    def calibration_pairs(self) -> list[CalibrationPair]:
+        return list(self._pairs)
+
+    def select_examples(self) -> tuple[dict[str, Any], ...]:
+        """Select the best few-shot examples from the calibration set."""
+        if self._selected_examples is None:
+            self._selected_examples = _select_diverse_examples(
+                self._pairs, max_examples=self._max_examples,
+            )
+        return self._selected_examples
+
+    def to_optimized_judge(
+        self,
+        provider: JudgeProvider,
+        *,
+        threshold: float = 0.7,
+        model: str = "claude-opus-4-6",
+    ) -> LLMJudge:
+        """Return an improved LLMJudge with calibrated prompt + examples."""
+        examples = self.select_examples()
+        return LLMJudge(
+            name="semantic_equivalence",
+            criteria=_CALIBRATED_CRITERIA,
+            input_template=_CALIBRATED_TEMPLATE,
+            provider=provider,
+            calibration_examples=examples,
+            threshold=threshold,
+            model=model,
+        )
+
+    def evaluate_agreement(
+        self,
+        judge: LLMJudge,
+    ) -> float:
+        """Compute human-agreement score by evaluating all calibration pairs.
+
+        Returns the mean absolute agreement (1 - |human_score - judge_score|)
+        across all calibration pairs.  This requires actual LLM calls.
+        """
+        if not self._pairs:
+            return 0.0
+
+        agreements: list[float] = []
+        for pair in self._pairs:
+            result = judge.evaluate(pair.adf_expression, pair.python_code)
+            agreement = 1.0 - abs(pair.human_score - result.score)
+            agreements.append(agreement)
+
+        return sum(agreements) / len(agreements)
+
+
+# ---------------------------------------------------------------------------
+# JudgeOptimizer — requires DSPy 3.x
+# ---------------------------------------------------------------------------
+
+class JudgeOptimizer:
+    """Wrap LLMJudge as a DSPy module and optimise with MIPROv2 or SIMBA.
+
+    Raises :class:`ImportError` if DSPy is not installed.
+    """
+
+    def __init__(
+        self,
+        provider: JudgeProvider,
+        *,
+        optimizer: str = "MIPROv2",
+        model: str = "claude-opus-4-6",
+        threshold: float = 0.7,
+    ) -> None:
+        try:
+            import dspy  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "DSPy 3.x is required for JudgeOptimizer. "
+                "Install it with: pip install dspy-ai>=3.0\n"
+                "For a DSPy-free alternative, use ManualCalibrator instead:\n"
+                "  from lakeflow_migration_validator.optimization.judge_optimizer "
+                "import ManualCalibrator"
+            ) from None
+
+        self._dspy = dspy
+        self._provider = provider
+        self._optimizer_name = optimizer
+        self._model = model
+        self._threshold = threshold
+        self._optimized_program: Any = None
+
+    def optimize(
+        self,
+        calibration_pairs: list[CalibrationPair],
+        metric_fn: Callable[..., float] | None = None,
+    ) -> None:
+        """Run DSPy optimisation against human-labelled calibration pairs.
+
+        Parameters
+        ----------
+        calibration_pairs:
+            Human-labelled expression pairs with ground-truth scores.
+        metric_fn:
+            A callable ``(example, prediction) -> float`` used by DSPy to
+            evaluate the judge quality.  If *None*, a default agreement
+            metric is used.
+        """
+        dspy = self._dspy
+
+        # Build DSPy examples
+        examples = []
+        for pair in calibration_pairs:
+            ex = dspy.Example(
+                adf_expression=pair.adf_expression,
+                python_code=pair.python_code,
+                human_score=pair.human_score,
+            ).with_inputs("adf_expression", "python_code")
+            examples.append(ex)
+
+        if metric_fn is None:
+            def metric_fn(example, prediction, trace=None):
+                predicted = float(prediction.score)
+                expected = float(example.human_score)
+                return 1.0 - abs(predicted - expected)
+
+        # Build DSPy module wrapping the judge prompt
+        class JudgeModule(dspy.Module):
+            def __init__(self_module):
+                super().__init__()
+                self_module.judge = dspy.ChainOfThought(
+                    "adf_expression, python_code -> score, reasoning"
+                )
+
+            def forward(self_module, adf_expression, python_code):
+                return self_module.judge(
+                    adf_expression=adf_expression,
+                    python_code=python_code,
+                )
+
+        module = JudgeModule()
+
+        # Select optimizer
+        if self._optimizer_name == "MIPROv2":
+            optimizer = dspy.MIPROv2(metric=metric_fn, auto="light")
+        elif self._optimizer_name == "SIMBA":
+            optimizer = dspy.SIMBA(metric=metric_fn)
+        else:
+            raise ValueError(
+                f"Unknown optimizer: {self._optimizer_name!r}. "
+                f"Supported: 'MIPROv2', 'SIMBA'."
+            )
+
+        self._optimized_program = optimizer.compile(
+            module,
+            trainset=examples,
+        )
+
+    def to_optimized_judge(self) -> LLMJudge:
+        """Return an LLMJudge with DSPy-optimised instructions and demos.
+
+        Must call :meth:`optimize` first.
+        """
+        if self._optimized_program is None:
+            raise RuntimeError(
+                "Call optimize() before to_optimized_judge(). "
+                "No optimisation has been run yet."
+            )
+
+        # Extract the optimised instruction and demos from the DSPy program
+        dspy = self._dspy
+        program = self._optimized_program
+
+        # Try to extract improved instructions from the optimised program
+        instructions = _CALIBRATED_CRITERIA
+        demos: list[dict[str, Any]] = []
+
+        # DSPy stores optimised predictors with demos
+        for _name, predictor in program.named_predictors():
+            if hasattr(predictor, "demos") and predictor.demos:
+                for demo in predictor.demos:
+                    demos.append({
+                        "input": getattr(demo, "adf_expression", ""),
+                        "output": getattr(demo, "python_code", ""),
+                        "score": float(getattr(demo, "human_score", 1.0)),
+                    })
+            # Extract optimised extended signature instruction if available
+            if hasattr(predictor, "extended_signature") and hasattr(
+                predictor.extended_signature, "instructions"
+            ):
+                instructions = predictor.extended_signature.instructions
+
+        calibration_examples = tuple(demos) if demos else ()
+
+        return LLMJudge(
+            name="semantic_equivalence",
+            criteria=instructions,
+            input_template=_CALIBRATED_TEMPLATE,
+            provider=self._provider,
+            calibration_examples=calibration_examples,
+            threshold=self._threshold,
+            model=self._model,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: auto-select best available calibrator
+# ---------------------------------------------------------------------------
+
+def create_calibrator(
+    calibration_path: str | Path,
+    provider: JudgeProvider | None = None,
+    *,
+    optimizer: str = "MIPROv2",
+    max_examples: int = 10,
+) -> ManualCalibrator | JudgeOptimizer:
+    """Return the best available calibrator.
+
+    If DSPy is installed and *provider* is given, returns a
+    :class:`JudgeOptimizer`.  Otherwise falls back to
+    :class:`ManualCalibrator`.
+    """
+    try:
+        import dspy  # noqa: F401
+        if provider is not None:
+            return JudgeOptimizer(provider, optimizer=optimizer)
+    except ImportError:
+        pass
+
+    return ManualCalibrator.from_file(calibration_path, max_examples=max_examples)

--- a/tests/unit/validation/test_judge_optimizer.py
+++ b/tests/unit/validation/test_judge_optimizer.py
@@ -1,0 +1,344 @@
+"""Unit tests for DSPy judge calibration with ManualCalibrator fallback."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lakeflow_migration_validator.optimization.judge_optimizer import (
+    CalibrationPair,
+    JudgeOptimizer,
+    ManualCalibrator,
+    _select_diverse_examples,
+    create_calibrator,
+    load_calibration_pairs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub provider for tests — no real LLM calls
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Mimics JudgeProvider without making network calls."""
+
+    def __init__(self, score: float = 0.85):
+        self._score = score
+        self.calls: list[dict] = []
+
+    def judge(self, prompt: str, model: str | None = None):
+        self.calls.append({"prompt": prompt, "model": model})
+        return {"score": self._score, "reasoning": "stub"}
+
+
+# ---------------------------------------------------------------------------
+# CalibrationPair format tests
+# ---------------------------------------------------------------------------
+
+class TestCalibrationPairFormat:
+    """Verify calibration pair schema and loading."""
+
+    def test_calibration_pair_has_required_fields(self):
+        pair = CalibrationPair(
+            adf_expression="@add(1, 2)",
+            python_code="(1 + 2)",
+            human_score=1.0,
+            category="math",
+            notes="perfect",
+        )
+        assert pair.adf_expression == "@add(1, 2)"
+        assert pair.python_code == "(1 + 2)"
+        assert pair.human_score == 1.0
+        assert pair.category == "math"
+        assert pair.notes == "perfect"
+
+    def test_calibration_pair_as_example_dict(self):
+        pair = CalibrationPair(
+            adf_expression="@toUpper('x')",
+            python_code="str('x').upper()",
+            human_score=0.9,
+        )
+        d = pair.as_example_dict()
+        assert d == {
+            "input": "@toUpper('x')",
+            "output": "str('x').upper()",
+            "score": 0.9,
+        }
+
+    def test_calibration_pair_defaults(self):
+        pair = CalibrationPair(
+            adf_expression="@x",
+            python_code="x",
+            human_score=0.5,
+        )
+        assert pair.category == ""
+        assert pair.notes == ""
+
+    def test_load_calibration_pairs_from_file(self, tmp_path: Path):
+        path = tmp_path / "cal.json"
+        path.write_text(
+            json.dumps({
+                "calibration_pairs": [
+                    {
+                        "adf_expression": "@add(1,2)",
+                        "python_code": "(1 + 2)",
+                        "human_score": 1.0,
+                        "category": "math",
+                        "notes": "perfect",
+                    },
+                    {
+                        "adf_expression": "@div(9,2)",
+                        "python_code": "(9 / 2)",
+                        "human_score": 0.5,
+                        "category": "math",
+                    },
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        pairs = load_calibration_pairs(path)
+
+        assert len(pairs) == 2
+        assert pairs[0].adf_expression == "@add(1,2)"
+        assert pairs[0].human_score == 1.0
+        assert pairs[0].category == "math"
+        assert pairs[1].human_score == 0.5
+        assert pairs[1].notes == ""
+
+    def test_load_calibration_pairs_empty_file(self, tmp_path: Path):
+        path = tmp_path / "empty.json"
+        path.write_text(json.dumps({"calibration_pairs": []}), encoding="utf-8")
+
+        pairs = load_calibration_pairs(path)
+
+        assert pairs == []
+
+    def test_load_golden_set_calibration_pairs(self):
+        """Verify the actual golden_sets/calibration_pairs.json is valid."""
+        golden_path = (
+            Path(__file__).resolve().parents[3]
+            / "golden_sets"
+            / "calibration_pairs.json"
+        )
+        if not golden_path.exists():
+            pytest.skip("calibration_pairs.json not found")
+
+        pairs = load_calibration_pairs(golden_path)
+
+        assert len(pairs) == 20
+        for pair in pairs:
+            assert pair.adf_expression, "adf_expression must not be empty"
+            assert pair.python_code, "python_code must not be empty"
+            assert 0.0 <= pair.human_score <= 1.0, (
+                f"human_score {pair.human_score} out of [0, 1] range"
+            )
+            assert pair.category, "category should be set for golden data"
+
+    def test_golden_set_has_score_diversity(self):
+        """Golden set must include low, mid, and high scores for calibration."""
+        golden_path = (
+            Path(__file__).resolve().parents[3]
+            / "golden_sets"
+            / "calibration_pairs.json"
+        )
+        if not golden_path.exists():
+            pytest.skip("calibration_pairs.json not found")
+
+        pairs = load_calibration_pairs(golden_path)
+        scores = [p.human_score for p in pairs]
+
+        assert any(s < 0.3 for s in scores), "Need at least one low-score pair"
+        assert any(0.3 <= s <= 0.7 for s in scores), "Need at least one mid-score pair"
+        assert any(s > 0.9 for s in scores), "Need at least one high-score pair"
+
+
+# ---------------------------------------------------------------------------
+# ManualCalibrator tests
+# ---------------------------------------------------------------------------
+
+class TestManualCalibrator:
+    """ManualCalibrator loads examples and produces improved judge."""
+
+    @pytest.fixture()
+    def sample_pairs(self) -> list[CalibrationPair]:
+        return [
+            CalibrationPair("@add(1,2)", "(1 + 2)", 1.0, "math"),
+            CalibrationPair("@div(9,2)", "(9 / 2)", 0.5, "math"),
+            CalibrationPair("@toUpper('x')", "'x'.upper()", 0.9, "string"),
+            CalibrationPair("@utcNow()", "datetime.now()", 0.4, "datetime"),
+            CalibrationPair("@concat('a','b','c')", "str('a')+str('b')", 0.3, "string"),
+            CalibrationPair("@equals(1,1)", "(1 == 1)", 1.0, "logical"),
+        ]
+
+    def test_manual_calibrator_loads_pairs(self, sample_pairs):
+        cal = ManualCalibrator(sample_pairs)
+        assert cal.calibration_pairs == sample_pairs
+
+    def test_manual_calibrator_from_file(self, tmp_path: Path):
+        path = tmp_path / "cal.json"
+        path.write_text(
+            json.dumps({
+                "calibration_pairs": [
+                    {
+                        "adf_expression": "@add(1,2)",
+                        "python_code": "(1 + 2)",
+                        "human_score": 1.0,
+                        "category": "math",
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        cal = ManualCalibrator.from_file(path)
+
+        assert len(cal.calibration_pairs) == 1
+        assert cal.calibration_pairs[0].human_score == 1.0
+
+    def test_manual_calibrator_selects_examples(self, sample_pairs):
+        cal = ManualCalibrator(sample_pairs, max_examples=4)
+        examples = cal.select_examples()
+
+        assert len(examples) == 4
+        # Each example must be a dict with input, output, score
+        for ex in examples:
+            assert "input" in ex
+            assert "output" in ex
+            assert "score" in ex
+            assert isinstance(ex["score"], float)
+
+    def test_manual_calibrator_selects_all_when_fewer_than_max(self, sample_pairs):
+        cal = ManualCalibrator(sample_pairs, max_examples=20)
+        examples = cal.select_examples()
+        assert len(examples) == len(sample_pairs)
+
+    def test_manual_calibrator_returns_empty_for_no_pairs(self):
+        cal = ManualCalibrator([])
+        examples = cal.select_examples()
+        assert examples == ()
+
+    def test_manual_calibrator_produces_optimized_judge(self, sample_pairs):
+        provider = _StubProvider()
+        cal = ManualCalibrator(sample_pairs, max_examples=5)
+        judge = cal.to_optimized_judge(provider, threshold=0.75, model="chatgpt-5-4")
+
+        assert judge.name == "semantic_equivalence"
+        assert judge.threshold == 0.75
+        assert judge.model == "chatgpt-5-4"
+        assert 1 <= len(judge.calibration_examples) <= 5
+        # Criteria should be the improved calibrated version
+        assert "Type coercion" in judge.criteria
+        assert "Edge cases" in judge.criteria
+
+    def test_optimized_judge_evaluates_successfully(self, sample_pairs):
+        provider = _StubProvider(score=0.88)
+        cal = ManualCalibrator(sample_pairs)
+        judge = cal.to_optimized_judge(provider)
+
+        result = judge.evaluate("@add(1,2)", "(1 + 2)")
+
+        assert result.score == 0.88
+        assert result.passed is True
+        assert len(provider.calls) == 1
+
+    def test_optimized_judge_prompt_includes_calibration_examples(self, sample_pairs):
+        provider = _StubProvider()
+        cal = ManualCalibrator(sample_pairs, max_examples=3)
+        judge = cal.to_optimized_judge(provider)
+
+        judge.evaluate("@test", "test")
+        prompt = provider.calls[0]["prompt"]
+
+        assert "Examples:" in prompt
+        assert "ADF Expression" in prompt
+        assert "Python Translation" in prompt
+
+    def test_select_diverse_examples_includes_score_range(self):
+        pairs = [
+            CalibrationPair("@a", "a", 1.0, "cat_a"),
+            CalibrationPair("@b", "b", 0.9, "cat_b"),
+            CalibrationPair("@c", "c", 0.5, "cat_c"),
+            CalibrationPair("@d", "d", 0.2, "cat_d"),
+            CalibrationPair("@e", "e", 0.0, "cat_e"),
+        ]
+        examples = _select_diverse_examples(pairs, max_examples=4)
+
+        scores = [ex["score"] for ex in examples]
+        # Must include at least one high and one low score
+        assert any(s >= 0.9 for s in scores), "Should include a high-score example"
+        assert any(s <= 0.3 for s in scores), "Should include a low-score example"
+
+
+# ---------------------------------------------------------------------------
+# JudgeOptimizer tests (DSPy not installed)
+# ---------------------------------------------------------------------------
+
+class TestJudgeOptimizerWithoutDSPy:
+    """JudgeOptimizer must raise a helpful ImportError when DSPy is absent."""
+
+    def test_optimizer_raises_import_error_without_dspy(self):
+        """Instantiating JudgeOptimizer without DSPy must fail with guidance."""
+        provider = _StubProvider()
+
+        # Ensure dspy is not importable (it should not be in this env)
+        with mock.patch.dict(sys.modules, {"dspy": None}):
+            with pytest.raises(ImportError, match="DSPy 3.x is required"):
+                JudgeOptimizer(provider)
+
+    def test_import_error_mentions_manual_calibrator(self):
+        provider = _StubProvider()
+
+        with mock.patch.dict(sys.modules, {"dspy": None}):
+            with pytest.raises(ImportError, match="ManualCalibrator"):
+                JudgeOptimizer(provider)
+
+    def test_import_error_mentions_pip_install(self):
+        provider = _StubProvider()
+
+        with mock.patch.dict(sys.modules, {"dspy": None}):
+            with pytest.raises(ImportError, match="pip install dspy-ai"):
+                JudgeOptimizer(provider)
+
+
+# ---------------------------------------------------------------------------
+# create_calibrator fallback
+# ---------------------------------------------------------------------------
+
+class TestCreateCalibrator:
+    """create_calibrator should fall back to ManualCalibrator without DSPy."""
+
+    def test_returns_manual_calibrator_without_dspy(self, tmp_path: Path):
+        path = tmp_path / "cal.json"
+        path.write_text(
+            json.dumps({
+                "calibration_pairs": [
+                    {
+                        "adf_expression": "@add(1,2)",
+                        "python_code": "(1 + 2)",
+                        "human_score": 1.0,
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(sys.modules, {"dspy": None}):
+            cal = create_calibrator(path, provider=_StubProvider())
+
+        assert isinstance(cal, ManualCalibrator)
+
+    def test_returns_manual_calibrator_when_no_provider(self, tmp_path: Path):
+        path = tmp_path / "cal.json"
+        path.write_text(
+            json.dumps({"calibration_pairs": []}),
+            encoding="utf-8",
+        )
+
+        cal = create_calibrator(path, provider=None)
+
+        assert isinstance(cal, ManualCalibrator)


### PR DESCRIPTION
## Summary
- Add `optimization/judge_optimizer.py` with `JudgeOptimizer` (DSPy MIPROv2/SIMBA) and `ManualCalibrator` (DSPy-free fallback) that selects diverse few-shot calibration examples and produces an improved `LLMJudge` with a richer, structured prompt template
- Add `golden_sets/calibration_pairs.json` with 20 human-scored ADF expression/Python pairs spanning all 6 categories (string, math, datetime, logical, collection, nested) with scores from 0.0 to 1.0
- Add 21 unit tests covering calibration pair format, ManualCalibrator loading/selection/judge production, JudgeOptimizer ImportError handling, and create_calibrator fallback logic

## Test plan
- [x] `PYTHONPATH=src pytest tests/unit/validation/test_judge_optimizer.py -v` — 21/21 passing
- [ ] Verify ManualCalibrator produces better judge agreement than uncalibrated default (requires LLM calls)
- [ ] When DSPy is installed, verify JudgeOptimizer.optimize() runs MIPROv2 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new judge-calibration logic that can change semantic-equivalence scoring by altering prompts and few-shot examples; DSPy integration is optional but adds a new dependency path when installed.
> 
> **Overview**
> Adds a new judge-calibration workflow: `ManualCalibrator` selects a diverse subset of human-labelled ADF/Python pairs and builds an `LLMJudge` with a more structured semantic-equivalence prompt, while `JudgeOptimizer` optionally uses DSPy (MIPROv2/SIMBA) to optimize instructions/demos when available.
> 
> Introduces `golden_sets/calibration_pairs.json` (20 scored examples across categories) and unit tests covering pair loading/schema, example selection behavior, DSPy-absent error handling, and `create_calibrator` fallback selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d01c7ea6c205f9c5d3acd1bfe49d8f0bef5f7e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->