### PR TITLE
fix: from_wkmigrate walks non-SetVariable activities for resolved expressions (L-F17)

### DIFF
--- a/src/lakeflow_migration_validator/adapters/wkmigrate_adapter.py
+++ b/src/lakeflow_migration_validator/adapters/wkmigrate_adapter.py
@@ -217,10 +217,17 @@ def _extract_resolved_expression_pairs(prepared_pipeline: Any, source_pipeline: 
             # canonical text is lost. We synthesise a (left op right)
             # expression on the IR side and pair it with the original ADF
             # expression captured from the source dict (when available).
+            #
+            # All three operands must be non-empty strings — otherwise the
+            # f-string would silently embed the literal "None" (or "") into
+            # python_code, and that bogus pair would inflate X-1/X-2
+            # coverage metrics. Defensive validation matches every other
+            # handler in this walker (each of which goes through
+            # _coerce_resolved_value or an isinstance check before emitting).
             op = getattr(task, "op", None)
             left = getattr(task, "left", None)
             right = getattr(task, "right", None)
-            if isinstance(op, str) and op:
+            if isinstance(op, str) and op and isinstance(left, str) and left and isinstance(right, str) and right:
                 python_code = f"({left} {op} {right})"
                 adf = _source_expression_at(source_activity, "expression") or f"@if_condition('{task_name}').expression"
                 pairs.append(ExpressionPair(adf_expression=adf, python_code=python_code))

--- a/tests/unit/validation/test_wkmigrate_adapter_lf17.py
+++ b/tests/unit/validation/test_wkmigrate_adapter_lf17.py
@@ -330,14 +330,37 @@ def test_adapter_existing_set_variable_extraction_still_works():
 
     snap = from_wkmigrate(source, prepared)
 
-    # Exactly one pair (no double-extraction from the new walker)
+    # Exactly one pair (no double-extraction from the new walker).
     set_var_pairs = [
         p for p in snap.resolved_expressions if "concat" in p.adf_expression or "result" in p.adf_expression
     ]
-    assert len(set_var_pairs) >= 1
+    assert len(set_var_pairs) == 1
     # And the source ADF expression IS preferred over the @variables('result') fallback
     # when present in the source dict (this is also a small upgrade vs. the previous
-    # adapter which always emitted the @variables() label)
+    # adapter which always emitted the @variables() label).
     pairs_with_concat = [p for p in snap.resolved_expressions if "@concat" in p.adf_expression]
     assert len(pairs_with_concat) == 1
     assert pairs_with_concat[0].python_code == "str('a') + str('b')"
+
+
+def test_adapter_skips_if_condition_with_missing_operands():
+    """If left or right is missing (None or empty), the IfCondition handler
+    must NOT emit a pair — otherwise python_code becomes the literal text
+    'None' or '() == ()' and silently inflates X-1/X-2 coverage. Cursor
+    Bugbot caught this on PR #20."""
+    source = {"activities": []}
+    # Build an IfConditionActivity with left=None to simulate a malformed IR
+    task = IfConditionActivity(
+        name="bad_if",
+        task_key="bad_if",
+        op="==",
+        left="",  # ← invalid: empty operand
+        right="1",
+    )
+    prepared = _build_minimal_prepared_for_task(task)
+
+    snap = from_wkmigrate(source, prepared)
+
+    # No pair emitted because left is empty
+    if_pairs = [p for p in snap.resolved_expressions if "if_condition" in p.adf_expression or "==" in p.python_code]
+    assert len(if_pairs) == 0


### PR DESCRIPTION
## Summary

Closes the **L-F17** finding from PR #19's L-F5 sweep: the lmv adapter previously only extracted `ExpressionPair` entries from `SetVariableActivity` tasks (`variable_name` + `variable_value`), so all other activity types adopted by wkmigrate (`Notebook.base_parameters`, `WebActivity.url`/`body`/`headers`, `IfCondition.expression`, `ForEach.items`, `Lookup.source.sql_reader_query`) silently produced **0 resolved expressions** even when wkmigrate had already done the resolution upstream. **X-1 systematically underreported** for any non-SetVariable context.

## What's new

### `_extract_resolved_expression_pairs(prepared_pipeline, source_pipeline)` walker

For each task in `prepared.pipeline.tasks`, dispatches on `isinstance` against the wkmigrate IR types and walks the expression-bearing fields:

| Activity | IR field(s) walked | Type |
|---|---|---|
| `SetVariableActivity` | `variable_value` | `str` |
| `DatabricksNotebookActivity` | `base_parameters` | `dict[str, str] \| None` |
| `WebActivity` | `url`, `body`, `headers` | `str \| ResolvedExpression`, plus dict-of-headers walk |
| `LookupActivity` | `source_query` | `str \| None` |
| `ForEachActivity` | `items_string` | `str` |
| `IfConditionActivity` | `op`, `left`, `right` | strings — synthesised into `(left op right)` since the original ADF predicate is decomposed at IR construction time |

For each extracted code string the walker looks up the original ADF expression text from the source pipeline JSON via a name-indexed walker (`_build_source_activity_index` + `_source_expression_at`). When the source has no matching expression, a synthetic label like `@notebook('task').base_parameters.k` is used — the `python_code` field is what dimensions actually measure.

### Two helpers

- **`_coerce_resolved_value(value)`** handles both `str` and `ResolvedExpression` IR types. Lazy-imports `ResolvedExpression` to keep the **LA-3 graceful-degradation invariant**: importing the adapter module must not require wkmigrate.
- **`_source_expression_at(activity, *path)`** walks a source dict to find the `{type: \"Expression\", value: \"@...\"}` leaf at a property path.

## In-vivo verification — `lmv sweep-activity-contexts` against `alpha_1@969e74d`

\`\`\`
context              BEFORE  AFTER    Δ      verdict
set_variable           200     200    = 0    control: no double-extract
notebook_base_param      0     200    +200   silent zero → fully extracted
if_condition             0      13    +13    logical-category booleans only
for_each                 0       0    = 0    W-10, wkmigrate-side block
web_body                 0     200    +200   silent zero → fully extracted
lookup_query             0       0    = 0    W-7, wkmigrate-side crash
copy_query               0       0    = 0    W-8, wkmigrate-side block
\`\`\`

**413 cells lifted from silent zero to real values out of 1400 total** (200 notebook + 13 if + 200 web). The remaining zeros are exactly the ones blocked on wkmigrate-side fixes (W-7, W-8, W-10) — L-F17 explicitly cannot reach those because wkmigrate never produces the relevant IR nodes for them.

The **13/200 IfCondition split is meaningful**: it's the cleavage between predicates the wkmigrate IfCondition translator handles cleanly (boolean ops in the `logical` category) vs. those it doesn't (string/math/datetime/collection/nested all fall through to placeholder). This is now a real, measurable signal lmv can use to track wkmigrate's IfCondition coverage.

## Test plan

| Gate | Before | After |
|---|---|---|
| `make test` | 289 passed | **289 passed** (+0) |
| `make test-all` | 321 passed, 1 skipped | **329 passed**, 1 skipped (+8) |
| `poetry run ruff check src tests` | clean | clean |
| `poetry run black --check src tests` | 104 unchanged | **104 unchanged** |

### 7 new tests in `tests/unit/validation/test_wkmigrate_adapter.py` (full tier)

- `test_adapter_extracts_notebook_base_parameters_expressions`
- `test_adapter_extracts_web_activity_url_and_body_resolved_expressions` (covers BOTH the `str` path and the `ResolvedExpression` path)
- `test_adapter_extracts_lookup_source_query`
- `test_adapter_extracts_for_each_items_string`
- `test_adapter_extracts_if_condition_decomposed_predicate`
- `test_adapter_uses_synthetic_label_when_source_expression_missing`
- `test_adapter_skips_notebook_base_parameters_with_empty_or_none_values`
- `test_adapter_existing_set_variable_extraction_still_works` (regression check — no double-counting; the source ADF expression is now preferred over the `@variables('name')` fallback when present)

## What this unblocks

- **X-1 / X-2 measurements are now honest for non-SetVariable contexts.** Future `/lmv-autodev` harvests will see real coverage values for Notebook, Web, IfCondition (the 13 boolean cells) instead of silent zeros.
- **The remaining zero rows are now unambiguous wkmigrate signals.** Any zero in `for_each` / `lookup_query` / `copy_query` is by definition a wkmigrate-side adoption gap (the adapter walks every IR type that COULD produce expressions). This is the asymmetric ratchet working as designed.
- **The 13/200 IfCondition cell** is the first non-binary measurement in the sweep matrix and is the right kind of signal for tracking incremental wkmigrate translator improvements.

## Out of scope (deliberate)

- **W-7 / W-8 / W-10 fixes** are wkmigrate-side and need separate work (deferred wkmigrate#28). They are documented in `dev/wkmigrate-issue-map.json` as of `1d927db`.
- **L-F18** (enrich placeholder warnings with `original_activity_type` so W-8/W-10 regexes can match by activity type rather than task_key substring) — separate small adapter PR.

## Provenance

`dev/autodev-sessions/LMV-AUTODEV-2026-04-08-session2.md` finding L-F17 + in-vivo verification via `/tmp/lmv_sweep_alpha1_post_lf17.json` (the same `lmv sweep-activity-contexts` invocation that produced PR #19's findings, re-run on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `from_wkmigrate` populates `resolved_expressions`, which can materially alter scoring/coverage metrics and semantic-equivalence evaluation across many pipelines. Logic is defensive and well-tested, but relies on wkmigrate IR field shapes that may vary across versions.
> 
> **Overview**
> Fixes an adapter gap where `from_wkmigrate` only emitted `ExpressionPair`s for `SetVariableActivity`, by adding an L-F17 walker that extracts resolved expressions from additional wkmigrate IR activities (notebook base parameters, web url/body/headers, lookup queries, foreach items, and if-condition predicates).
> 
> The adapter now prefers the original source ADF `@...` expression when present (via a name-indexed source JSON lookup) and otherwise falls back to synthetic labels, while defensively skipping empty/invalid values and supporting `ResolvedExpression` via lazy imports to preserve graceful degradation when wkmigrate isn’t installed.
> 
> Adds a new unit test module (skipped unless wkmigrate alpha_1+ is available) covering the new extraction paths plus regressions for `SetVariableActivity` and malformed `IfConditionActivity` operands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83e14feb43f7e4357b8e27f4a973903b6edfd9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->