### PR TITLE
step-7: Vista Cliente semantic validation sweep (X-1 datapoint #2 at wkmigrate cfb49e6)

### DIFF
--- a/dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md
+++ b/dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md
@@ -1,0 +1,190 @@
+# LMV-AUTODEV Step 7 — Vista Cliente Semantic Validation Sweep
+
+**Date:** 2026-04-23
+**Branch:** `feature/step-7-vista-cliente-sweep`
+**Operator:** autodev agent (single-run execution)
+**wkmigrate SHA pinned:** `cfb49e64237185b62ead985a12e320f029c221a6` (`pr/27-4-integration-tests`, read-only)
+**lmv base SHA:** `f616be3` (`main`)
+
+---
+
+## Register 1 — Instructions
+
+Execute Step 7 of the wkmigrate coverage roadmap: add a second real-corpus X-1
+datapoint by sweeping the Vista Cliente (VC) ADF corpus (119 pipelines, 212
+IfCondition activities, under `/Users/miguel.peralvo/Downloads/DataFactory/pipeline/`)
+through wkmigrate at SHA `cfb49e6`. Build a stratified 200+ expression golden set,
+run `lmv sweep-activity-contexts` (primary `if_condition`, secondary all-contexts),
+replay CRP0001 baseline at the same SHA for cross-regression, and report X-1/X-2/X-6
+KPIs vs. the 0.8317 CRP0001 baseline with ±5% hard-gate flagging. Produce a session
+ledger (this file) and a findings report; list candidate wkmigrate issues (do not file).
+
+## Register 2 — Constraints
+
+### L-series hard gates (zero tolerance, STOP on trip)
+- **LR-1** `make test` 100% — not invoked this session (no src/tests changes). Status: N/A (empty diff).
+- **LR-2** 0 regressions — by construction; only new files added. Status: GREEN.
+- **LA-1** adapter invariant — only `tests/unit/validation/test_wkmigrate_adapter.py` imports `wkmigrate` outside `src/lakeflow_migration_validator/adapters/wkmigrate_adapter.py`. Status: GREEN.
+- **LA-2** contract frozen — no `src/lakeflow_migration_validator/contract.py` change. Status: GREEN.
+- **LT-3** regression-check exit 0 — not invoked (no src change). Status: N/A.
+
+### X-series soft gates (5% tolerance, FLAG on trip, continue)
+- **X-1** mean `expression_coverage` ≥ 0.80.
+- **X-2** mean `semantic_equivalence` ≥ 0.75.
+- **X-6** per-canonical-category coverage ≥ 0.70.
+- CRP0001 replay hard-gate: |replay − 0.8317| ≤ 0.05.
+
+## Register 3 — Stopping criteria
+
+- **Primary** — All task-brief deliverables (1-10) complete; plan, golden set,
+  sweeps, KPIs, ledger, findings report committed and pushed.
+- **Abort** — Any L-series hard gate trip → STOP, write partial ledger, ask user.
+- **Flag-and-continue** — Any X-series movement > 5% with empty `git diff src/ tests/`
+  (wkmigrate attribution). CRP0001 replay crossing ±5% → flag as finding.
+
+---
+
+## Methods
+
+### Golden set build (step 4)
+- Extractor: `scripts/extract_vista_cliente_expressions.py`
+- Output: `golden_sets/vista_cliente_expressions.json` (200 sampled from 212 raw VC IfCondition expressions)
+- Histogram: `dev/findings/vista-cliente-category-histogram-2026-04-23.json`
+- Stratification: 9 VC buckets (6 realized in corpus) × canonical 6 categories, floor 12/bucket, proportional fill to 200.
+- **Unique expressions in the 200-sample: 30** (heavy duplication: same template reused across pipelines; acceptable because we are measuring VC-corpus behaviour, not unique-expression breadth).
+
+### Sweeps (step 5)
+- Primitive: `lmv sweep-activity-contexts` (X-2-via-`batch-expressions` is L-8 backlog, not implemented).
+- **Primary:** VC @ `contexts=if_condition` → `dev/results/step-7-vista-cliente/sweep-if-condition-2026-04-23.json`
+- **Secondary:** VC @ all 7 contexts → `dev/results/step-7-vista-cliente/sweep-all-contexts-2026-04-23.json`
+- **CRP0001 replay:** `golden_sets/expressions.json` @ `contexts=if_condition` → `dev/results/step-7-vista-cliente/crp0001-baseline-replay-2026-04-23.json`
+- **`lmv batch` NOT usable** on `expressions.json` shape — expects `{pipelines:[...]}` suite. `KeyError: 'pipelines'` confirmed. X-2 would require reshaping golden sets into pipeline suites; deferred.
+
+### KPI aggregation
+- Script: `scripts/compute_step7_kpis.py`
+- Summary JSON: `dev/results/step-7-vista-cliente/step7-kpi-summary-2026-04-23.json`
+
+---
+
+## Baseline vs post-sweep KPI tables
+
+### X-1 Expression Coverage (if_condition)
+
+| Corpus | Resolved | Total | Coverage | Baseline | Δ vs baseline | Within ±5% |
+|---|---|---|---|---|---|---|
+| CRP0001 baseline (pinned, historical) | — | — | 0.8317 | 0.8317 | 0.0000 | yes |
+| CRP0001 replay @ cfb49e6 | 208 | 208 | **1.0000** | 0.8317 | **+0.1683** | **NO (HARD-GATE FLAG)** |
+| Vista Cliente @ cfb49e6 | 200 | 200 | **1.0000** | 0.8317 | +0.1683 | N/A (new corpus) |
+
+**Hard-gate flag:** CRP0001 replay moved from 0.8317 → 1.0000 (+16.83 pp) at SHA `cfb49e6` with an empty lmv-src diff since the baseline. Per X-series attribution: wkmigrate-side improvement between baseline measurement and `cfb49e6`. Likely drivers: CRP-11 wrapper (`87a5ecf`) + CCS adapter wiring fix (`c897e78`) + recent expression-translator landings. **This is good news, not a regression — but the baseline number is stale and should be re-pinned.**
+
+### X-2 Semantic Equivalence (if_condition)
+
+| Corpus | Status |
+|---|---|
+| CRP0001 | **BLOCKED** — `DATABRICKS_HOST` unset; judge-dependent primitive unreachable. |
+| Vista Cliente | **BLOCKED** — same env block + `expected_python` null on all 200 VC entries (VC lacks oracle). |
+
+### X-6 Per-canonical-category Coverage (target ≥ 0.70)
+
+| Category | CRP0001 resolved/total | CRP0001 cov | VC resolved/total | VC cov | Δ (VC−CRP) | VC pass |
+|---|---|---|---|---|---|---|
+| collection | 41/41 | 1.0000 | — | — | — | n/a |
+| datetime | 33/33 | 1.0000 | — | — | — | n/a |
+| logical | 33/33 | 1.0000 | 25/25 | 1.0000 | +0.0000 | yes |
+| math | 34/34 | 1.0000 | — | — | — | n/a |
+| nested | 33/33 | 1.0000 | 175/175 | 1.0000 | +0.0000 | yes |
+| string | 34/34 | 1.0000 | — | — | — | n/a |
+
+VC corpus only exercises `logical` (25) and `nested` (175) canonical categories — reflective of actual VC IfCondition usage: predominantly parameter-ref and variable-ref predicates. Both pass ≥ 0.70.
+
+### Per-VC-category breakdown (9-bucket, VC-only)
+
+| VC category | Count in sample | Resolved | Coverage |
+|---|---|---|---|
+| pipeline_param_ref | 149 | 149 | 1.0000 |
+| variables_ref | 24 | 24 | 1.0000 |
+| compound_and | 14 | 14 | 1.0000 |
+| equals_binary | 6 | 6 | 1.0000 |
+| compound_or | 5 | 5 | 1.0000 |
+| bare_activity_output | 2 | 2 | 1.0000 |
+| compound_and+or+equals nested_predicate | 0 | — | — |
+| contains_intersection_empty | 0 | — | — |
+| concat_string | 0 | — | — |
+
+Raw VC corpus (212 activities) contained no `nested_predicate`, `contains_intersection_empty`, or `concat_string` patterns — a useful corpus characterization result on its own.
+
+### Secondary: VC all-contexts resolution (X-1 across 7 contexts)
+
+| Context | Resolved/Total | Coverage | not_translatable_count | Observation |
+|---|---|---|---|---|
+| copy_query | 200/200 | 1.0000 | 36 | Clean |
+| for_each | **0/200** | **0.0000** | 200 | **Placeholder substitution** — wkmigrate does not recognize `ForEach` when wrapped at this synthetic context → every pipeline gets a `placeholder_activity` substitution. HIGH severity. |
+| if_condition | 200/200 | 1.0000 | 194 | Clean (194 are inline taskValues warnings, not failures) |
+| lookup_query | 200/200 | 1.0000 | **200** | Resolves but every pipeline emits a not_translatable warning — smells like CRP-28 Lookup translator gap. MEDIUM severity. |
+| notebook_base_param | 200/200 | 1.0000 | 36 | Clean |
+| set_variable | 200/200 | 1.0000 | 36 | Clean |
+| web_body | 200/200 | 1.0000 | 36 | Clean |
+
+---
+
+## Findings
+
+### Finding F-7.1 (HIGH) — CRP0001 baseline X-1 is stale
+- **Evidence:** CRP0001 replay @ `cfb49e6` = 1.0000 (+16.83 pp over 0.8317 baseline).
+- **Attribution:** wkmigrate advancement (empty lmv diff since baseline).
+- **Impact:** The 0.8317 pin in `dev/meta-kpis/wkmigrate-issue-27-meta-kpis.md` row X-1 is obsolete; new X-1 pin should be 1.0000 at SHA `cfb49e6` for CRP0001.
+- **Action:** Re-pin X-1 baseline in a follow-up commit (out of scope for this ledger).
+
+### Finding F-7.2 (HIGH) — `ForEach` context: 100% placeholder substitution
+- **Signature:** 200/200 VC expressions wrapped inside a synthetic `ForEach` activity produced `Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).`
+- **VC prevalence:** Every VC expression tested against this context fails.
+- **Candidate wkmigrate issue (title):** `wkmigrate: ForEach activity emitted by synthetic wrapper not recognized by translator → placeholder`.
+- **Hypothesis:** The synthetic wrapper in `src/lakeflow_migration_validator/synthetic/activity_context_wrapper.py` emits `type=ForEach` JSON that diverges from what wkmigrate's ADF loader expects (e.g. missing `typeProperties.items` or a specific `isSequential` field). Could be a wrapper bug, not a wkmigrate one — needs double-source check.
+
+### Finding F-7.3 (MEDIUM) — `lookup_query` context: 100% not_translatable noise
+- **Signature:** 200/200 VC expressions in a `Lookup` activity query context resolve to Python code BUT every pipeline emits a `not_translatable` warning.
+- **Hypothesis:** Consistent with the known CRP-28 Lookup translator gap (`cli.py:297` docstring literally names `wkmigrate#28` as the deferred item). Expected noise until #28 lands.
+
+### Finding F-7.4 (MEDIUM) — VC corpus is template-heavy (duplication ratio 30/200)
+- **Signature:** 200 sampled VC expressions collapse to only 30 unique expression strings.
+- **Interpretation:** VC pipelines use a small library of IfCondition templates re-instantiated 7× on average. This means our X-1 number for VC is really measuring 30-template-coverage, not 200-expression-coverage. A healthy dedup-aware metric would give `30/30 = 1.0000` but with much tighter confidence bounds.
+- **Recommendation:** Add `dedup_by_expression` option to `sweep-activity-contexts` so operators can report both views.
+
+### Finding F-7.5 (LOW) — VC IfCondition patterns are narrow
+- VC uses only 6 of 9 classified VC buckets. No `contains/intersection/empty`, no `concat/string-manip`, no deep-nested compound predicates. This is meaningful corpus intel for QBR/scope planning.
+
+---
+
+## Convergence report
+
+- **Categories above ≥ 0.70 X-6 target:** `logical` (1.0000), `nested` (1.0000) on VC; all 6 on CRP0001. Zero categories below target.
+- **Categories below target:** none.
+- **X-series net movement:** +16.83 pp CRP0001 replay (flag-and-continue); +16.83 pp VC new datapoint.
+- **L-series status:** all green / N/A (no src changes this session).
+
+## Blockers
+
+- **`DATABRICKS_HOST` unset** → X-2 semantic_equivalence is BLOCKED for both corpora.
+- **`lmv batch-expressions` does not exist** (L-8 backlog) → had to use `sweep-activity-contexts` + would need reshaping for `lmv batch`; the latter errors with `KeyError: 'pipelines'` on expression-shaped golden sets.
+- **Google Docs fetch (ADC quota project)** → plan doc was synthesized from the local agent plan file, not the Google Doc directly.
+
+## Reproduction
+
+```bash
+cd /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator
+git checkout feature/step-7-vista-cliente-sweep
+python3 scripts/extract_vista_cliente_expressions.py \
+  --corpus ~/Downloads/DataFactory/pipeline \
+  --out golden_sets/vista_cliente_expressions.json \
+  --hist dev/findings/vista-cliente-category-histogram-2026-04-23.json
+uv run lmv sweep-activity-contexts \
+  --golden-set golden_sets/vista_cliente_expressions.json \
+  --contexts if_condition \
+  --output dev/results/step-7-vista-cliente/sweep-if-condition-2026-04-23.json
+uv run lmv sweep-activity-contexts \
+  --golden-set golden_sets/expressions.json \
+  --contexts if_condition \
+  --output dev/results/step-7-vista-cliente/crp0001-baseline-replay-2026-04-23.json
+python3 scripts/compute_step7_kpis.py
+```

--- a/dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md
+++ b/dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md
@@ -12,7 +12,7 @@
 
 Execute Step 7 of the wkmigrate coverage roadmap: add a second real-corpus X-1
 datapoint by sweeping the Vista Cliente (VC) ADF corpus (119 pipelines, 212
-IfCondition activities, under `/Users/miguel.peralvo/Downloads/DataFactory/pipeline/`)
+IfCondition activities, under `<CORPUS_DIR>/`)
 through wkmigrate at SHA `cfb49e6`. Build a stratified 200+ expression golden set,
 run `lmv sweep-activity-contexts` (primary `if_condition`, secondary all-contexts),
 replay CRP0001 baseline at the same SHA for cross-regression, and report X-1/X-2/X-6
@@ -172,10 +172,10 @@ Raw VC corpus (212 activities) contained no `nested_predicate`, `contains_inters
 ## Reproduction
 
 ```bash
-cd /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator
+cd <REPO_ROOT>
 git checkout feature/step-7-vista-cliente-sweep
 python3 scripts/extract_vista_cliente_expressions.py \
-  --corpus ~/Downloads/DataFactory/pipeline \
+  --corpus <CORPUS_DIR> \
   --out golden_sets/vista_cliente_expressions.json \
   --hist dev/findings/vista-cliente-category-histogram-2026-04-23.json
 uv run lmv sweep-activity-contexts \

--- a/dev/findings/vista-cliente-category-histogram-2026-04-23.json
+++ b/dev/findings/vista-cliente-category-histogram-2026-04-23.json
@@ -1,0 +1,17 @@
+{
+  "corpus_dir": "/Users/miguel.peralvo/Downloads/DataFactory/pipeline",
+  "total_if_condition_expressions": 212,
+  "per_vc_category": {
+    "pipeline_param_ref": 161,
+    "compound_and": 14,
+    "variables_ref": 24,
+    "equals_binary": 6,
+    "compound_or": 5,
+    "bare_activity_output": 2
+  },
+  "per_canonical_category": {
+    "nested": 187,
+    "logical": 25
+  },
+  "pipelines_seen": 119
+}

--- a/dev/findings/vista-cliente-category-histogram-2026-04-23.json
+++ b/dev/findings/vista-cliente-category-histogram-2026-04-23.json
@@ -1,5 +1,5 @@
 {
-  "corpus_dir": "/Users/miguel.peralvo/Downloads/DataFactory/pipeline",
+  "corpus_dir": "<CORPUS_DIR>",
   "total_if_condition_expressions": 212,
   "per_vc_category": {
     "pipeline_param_ref": 161,

--- a/dev/plan-lmv-step-7-vista-cliente-sweep.md
+++ b/dev/plan-lmv-step-7-vista-cliente-sweep.md
@@ -1,13 +1,13 @@
 # Step 7 Plan — Vista Cliente Semantic Validation Sweep (lmv)
 
-_Source: Google Doc `1zNokeWpHl-yWfCJd0rDrTo0sShdqVcP4pBEH7Awaul4` was inaccessible at execution time (ADC quota project missing for `docs.googleapis.com`). This document therefore summarizes the agent-reviewed plan at `/Users/miguel.peralvo/.claude/plans/tomando-en-cuenta-este-memoized-simon-agent-aa7d52dbb9cccd251.md`._
+_Source: Google Doc `1zNokeWpHl-yWfCJd0rDrTo0sShdqVcP4pBEH7Awaul4` was inaccessible at execution time (ADC quota project missing for `docs.googleapis.com`). This document therefore summarizes the agent-reviewed plan at `<AGENT_PLANS_DIR>/tomando-en-cuenta-este-memoized-simon-agent-aa7d52dbb9cccd251.md`._
 
 ## Target state
-- **Repo:** `/Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator`
+- **Repo:** `<REPO_ROOT>`
 - **wkmigrate SHA pinned:** `cfb49e6` (`pr/27-4-integration-tests`)
 - **Branch:** `feature/step-7-vista-cliente-sweep` off `main` (`f616be3`)
 - **Date:** 2026-04-23
-- **VC corpus:** `/Users/miguel.peralvo/Downloads/DataFactory/pipeline/` — 327 pipelines
+- **VC corpus:** `<CORPUS_DIR>/` — 327 pipelines
 
 ## Motivation
 After Step 6 landed CRP0001 baseline X-1 = 0.8317, we need a second real-corpus datapoint to verify the resolution-rate KPI generalizes. Vista Cliente (VC) is the next ADF corpus in scope and has 212 IfCondition activities across 119 pipelines with complex compound predicates.

--- a/dev/plan-lmv-step-7-vista-cliente-sweep.md
+++ b/dev/plan-lmv-step-7-vista-cliente-sweep.md
@@ -1,0 +1,45 @@
+# Step 7 Plan — Vista Cliente Semantic Validation Sweep (lmv)
+
+_Source: Google Doc `1zNokeWpHl-yWfCJd0rDrTo0sShdqVcP4pBEH7Awaul4` was inaccessible at execution time (ADC quota project missing for `docs.googleapis.com`). This document therefore summarizes the agent-reviewed plan at `/Users/miguel.peralvo/.claude/plans/tomando-en-cuenta-este-memoized-simon-agent-aa7d52dbb9cccd251.md`._
+
+## Target state
+- **Repo:** `/Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator`
+- **wkmigrate SHA pinned:** `cfb49e6` (`pr/27-4-integration-tests`)
+- **Branch:** `feature/step-7-vista-cliente-sweep` off `main` (`f616be3`)
+- **Date:** 2026-04-23
+- **VC corpus:** `/Users/miguel.peralvo/Downloads/DataFactory/pipeline/` — 327 pipelines
+
+## Motivation
+After Step 6 landed CRP0001 baseline X-1 = 0.8317, we need a second real-corpus datapoint to verify the resolution-rate KPI generalizes. Vista Cliente (VC) is the next ADF corpus in scope and has 212 IfCondition activities across 119 pipelines with complex compound predicates.
+
+## Golden set shape
+- Path: `golden_sets/vista_cliente_expressions.json`
+- Structure: `{count, expressions:[{adf_expression, category (canonical 6), vc_category (9 VC buckets), expected_python (nullable), source:{pipeline, activity_name, depth}}]}`
+- Sampling: stratified across 9 VC buckets (`compound_and`, `compound_or`, `nested_predicate`, `equals_binary`, `contains_intersection_empty`, `bare_activity_output`, `variables_ref`, `concat_string`, `pipeline_param_ref`), min floor 12/bucket, total ≥ 200.
+- VC→canonical category mapping preserves X-6 per-category KPI compatibility.
+
+## Primitives used
+- `uv run lmv sweep-activity-contexts --contexts if_condition` for the primary X-1 resolution-rate sweep.
+- `uv run lmv batch --threshold 75` for X-2 semantic_equivalence on hand-seeded subset (requires `DATABRICKS_HOST` for judge — probe first, otherwise mark BLOCKED).
+- `uv run lmv sweep-activity-contexts` (all contexts) as an informational secondary run.
+- `lmv batch-expressions` does NOT exist (L-8 backlog); this plan uses the two above instead.
+
+## KPIs / Gates
+- **X-1 expression_coverage ≥ 0.80** — primary.
+- **X-2 semantic_equivalence ≥ 0.75** — partial on VC (hand-seeded subset).
+- **X-6 per-canonical-category ≥ 0.70** — 6 canonical categories × 2 corpora.
+- **Hard gate:** CRP0001 replay at same SHA must be within ±5% of 0.8317. Flag (not abort) if violated.
+- **L-series hard gates:** LR-1/LR-2/LA-1/LA-2/LT-3 — zero tolerance. Stop session if tripped.
+
+## Deliverables (all in this branch)
+1. `dev/plan-lmv-step-7-vista-cliente-sweep.md` (this file)
+2. `scripts/extract_vista_cliente_expressions.py` — the VC corpus extractor
+3. `scripts/compute_step7_kpis.py` — KPI aggregator
+4. `golden_sets/vista_cliente_expressions.json` — 200+ stratified sample
+5. `dev/findings/vista-cliente-category-histogram-2026-04-23.json` — full bucket histogram
+6. `dev/results/step-7-vista-cliente/` — primary/secondary/CRP0001-replay sweep JSONs
+7. `dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md` — session ledger (Register 1/2/3)
+8. `dev/reports/step-7-vista-cliente-findings-2026-04-23.md` — findings report
+
+## Execution order
+§1 branch → §2 pre-flight → §3 golden set → §4 sweeps → §5 KPI compute → §6 ledger → §7 findings → §8 commit+push.

--- a/dev/reports/step-7-vista-cliente-findings-2026-04-23.md
+++ b/dev/reports/step-7-vista-cliente-findings-2026-04-23.md
@@ -1,0 +1,116 @@
+# Step 7 — Vista Cliente Semantic Validation Sweep: Findings
+
+**Date:** 2026-04-23
+**Branch:** `feature/step-7-vista-cliente-sweep`
+**wkmigrate SHA:** `cfb49e6`
+**lmv base SHA:** `f616be3` (main)
+**Session ledger:** `dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md`
+
+## TL;DR
+
+Vista Cliente (VC) X-1 resolution rate for `if_condition` is **1.0000** (200/200)
+at wkmigrate `cfb49e6` — above the 0.80 target and above the 0.8317 CRP0001
+historical baseline by +16.83 pp. The same replay on the CRP0001 golden set at
+the same SHA also returns **1.0000**, which trips the ±5% hard-gate relative to
+the historical baseline — attribution is wkmigrate advancement, not lmv, and
+the 0.8317 baseline number should be re-pinned. X-2 semantic-equivalence is
+BLOCKED for both corpora (`DATABRICKS_HOST` unset; VC has no `expected_python`
+oracle). The all-contexts secondary sweep uncovered a high-severity systemic
+failure on the `for_each` synthetic context (0/200 resolved, 200 placeholders),
+which is the primary candidate wkmigrate issue from this sweep.
+
+## Table 1 — X-1 / X-2 / X-6 (CRP0001 baseline vs CRP0001 replay vs VC)
+
+### X-1 Expression Coverage (if_condition)
+
+| Corpus | Resolved | Total | Coverage | Δ vs 0.8317 baseline | Status |
+|---|---|---|---|---|---|
+| CRP0001 baseline (historical) | — | — | 0.8317 | 0 | reference |
+| CRP0001 replay @ `cfb49e6` | 208 | 208 | **1.0000** | +0.1683 | **hard-gate flag** |
+| Vista Cliente @ `cfb49e6` | 200 | 200 | **1.0000** | +0.1683 | pass |
+
+### X-2 Semantic Equivalence (if_condition)
+
+| Corpus | Status |
+|---|---|
+| CRP0001 replay | BLOCKED — `DATABRICKS_HOST` unset |
+| Vista Cliente | BLOCKED — `DATABRICKS_HOST` unset + `expected_python` null |
+
+### X-6 Per-canonical-category Coverage (target ≥ 0.70)
+
+| Category | CRP0001 cov | VC cov | Δ | VC pass |
+|---|---|---|---|---|
+| collection | 1.0000 | — | — | n/a |
+| datetime | 1.0000 | — | — | n/a |
+| logical | 1.0000 | 1.0000 | 0.0000 | yes |
+| math | 1.0000 | — | — | n/a |
+| nested | 1.0000 | 1.0000 | 0.0000 | yes |
+| string | 1.0000 | — | — | n/a |
+
+## Table 2 — Secondary sweep (VC all 7 contexts)
+
+| Context | Coverage | not_translatable | Note |
+|---|---|---|---|
+| copy_query | 1.0000 | 36 | clean |
+| **for_each** | **0.0000** | **200** | **placeholder substitution for all 200** |
+| if_condition | 1.0000 | 194 | clean (taskValues warnings) |
+| lookup_query | 1.0000 | 200 | every pipeline emits not_translatable — CRP-28 pattern |
+| notebook_base_param | 1.0000 | 36 | clean |
+| set_variable | 1.0000 | 36 | clean |
+| web_body | 1.0000 | 36 | clean |
+
+## Top divergent categories (X-6 Δ analysis)
+
+VC X-6 is tied with CRP0001 on the 2 shared categories (`logical`, `nested`),
+so there are **no divergent canonical categories** within the if_condition
+primary sweep. Divergence surfaces only in the secondary all-contexts sweep,
+where VC expressions fail on 2 contexts that are not in-scope for X-1.
+
+### Top 5 divergent categories (reading across corpus + context pairs)
+
+| Rank | Category | CRP0001 | VC | Δ | Hypothesis |
+|---|---|---|---|---|---|
+| 1 | any × `for_each` | n/a | 0.0000 | — | Synthetic wrapper emits `type=ForEach` JSON that wkmigrate's ADF loader treats as unrecognized, producing a `DatabricksNotebookActivity` placeholder. Most likely a wrapper-contract bug (missing `typeProperties.items` / `isSequential`), not a wkmigrate translator gap. |
+| 2 | any × `lookup_query` | n/a | 1.0000 (noisy) | — | 200/200 not_translatable warnings despite resolution — consistent with known wkmigrate #28 Lookup/Copy translator adoption gap called out at `cli.py:296`. |
+| 3 | `logical` × `if_condition` | 1.0000 | 1.0000 | 0 | No divergence — VC compound `@and`/`@or` predicates resolve identically to CRP0001 synthetic logical. |
+| 4 | `nested` × `if_condition` | 1.0000 | 1.0000 | 0 | No divergence — VC `pipeline().parameters.X` / `variables('X')` patterns resolve identically. |
+| 5 | VC-bucket `compound_and` (N=14) | — | 1.0000 | — | `@and(variables('continue'), variables('testPassed'))` and `@and(..., pipeline().parameters.testing, variables('continue'))` all resolve; no 3+ level compound failures observed. |
+
+## Candidate wkmigrate issues (list only; DO NOT file)
+
+### Candidate 1 — `wkmigrate: ForEach activity emitted by synthetic-context wrapper treated as unknown type`
+- **Signature:** Wrapping any expression inside a synthetic `ForEach` activity (as emitted by `synthetic/activity_context_wrapper.py` in the `for_each` context) triggers `placeholder_activity` substitution 100% of the time with the message: _"Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type)."_
+- **VC prevalence:** 200/200 in the secondary sweep (every VC expression).
+- **Severity:** HIGH — either a real wkmigrate translator gap or a wrapper-contract drift; either way it invalidates the `for_each` dimension of the sweep KPI.
+- **Next step:** Diff what the wrapper emits against a real ADF ForEach JSON payload (from the VC corpus) to distinguish wrapper-bug from wkmigrate-bug.
+
+### Candidate 2 — `wkmigrate: Lookup/Copy translator adoption gap (CRP-28) — every Lookup pipeline emits not_translatable warning`
+- **Signature:** Any expression wrapped in a `Lookup` activity `source.query` returns a resolved Python translation BUT also emits a `not_translatable` entry.
+- **VC prevalence:** 200/200 in the secondary `lookup_query` sweep.
+- **Severity:** MEDIUM — already known (`cli.py:297` docstring, `dev/autodev-sessions/LMV-AUTODEV-2026-04-08-session2.md` L-F5). Confirmed still present at `cfb49e6`.
+- **Next step:** Track CRP-28 landing.
+
+### Candidate 3 — `wkmigrate: variables() reference inside IfCondition emits best-effort taskValues fallback with warning`
+- **Signature:** `@and(variables('continue'), variables('testPassed'))` resolves to a `dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')` pair, but emits the warning `"variables('continue') producer not in context cache; emitting best-effort taskKey='set_variable_continue'. Likely the SetVariable lives inside a multi-activity ForEach — the resulting lookup will fail"`.
+- **VC prevalence:** Observed in every `variables_ref` expression (24/24 in the VC sample).
+- **Severity:** MEDIUM — produces Python that compiles but may fail at runtime when the SetVariable producer is actually inside a ForEach. The warning is correct; the need is a fix for the ForEach-SetVariable producer resolution.
+
+## Reproduction one-liner
+
+```bash
+cd /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator && \
+git checkout feature/step-7-vista-cliente-sweep && \
+python3 scripts/extract_vista_cliente_expressions.py \
+  --corpus ~/Downloads/DataFactory/pipeline \
+  --out golden_sets/vista_cliente_expressions.json \
+  --hist dev/findings/vista-cliente-category-histogram-2026-04-23.json && \
+uv run lmv sweep-activity-contexts \
+  --golden-set golden_sets/vista_cliente_expressions.json \
+  --contexts if_condition \
+  --output dev/results/step-7-vista-cliente/sweep-if-condition-2026-04-23.json && \
+uv run lmv sweep-activity-contexts \
+  --golden-set golden_sets/expressions.json \
+  --contexts if_condition \
+  --output dev/results/step-7-vista-cliente/crp0001-baseline-replay-2026-04-23.json && \
+python3 scripts/compute_step7_kpis.py
+```

--- a/dev/reports/step-7-vista-cliente-findings-2026-04-23.md
+++ b/dev/reports/step-7-vista-cliente-findings-2026-04-23.md
@@ -98,10 +98,10 @@ where VC expressions fail on 2 contexts that are not in-scope for X-1.
 ## Reproduction one-liner
 
 ```bash
-cd /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator && \
+cd <REPO_ROOT> && \
 git checkout feature/step-7-vista-cliente-sweep && \
 python3 scripts/extract_vista_cliente_expressions.py \
-  --corpus ~/Downloads/DataFactory/pipeline \
+  --corpus <CORPUS_DIR> \
   --out golden_sets/vista_cliente_expressions.json \
   --hist dev/findings/vista-cliente-category-histogram-2026-04-23.json && \
 uv run lmv sweep-activity-contexts \

--- a/dev/results/step-7-vista-cliente/crp0001-baseline-replay-2026-04-23.json
+++ b/dev/results/step-7-vista-cliente/crp0001-baseline-replay-2026-04-23.json
@@ -1,0 +1,2574 @@
+{
+  "by_cell": {
+    "collection,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 41,
+      "placeholder_count": 0,
+      "resolved": 41,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@coalesce(null, 'x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+        },
+        {
+          "adf_expression": "@empty(createArray())",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(len([]) == 0)"
+        },
+        {
+          "adf_expression": "@string(42)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "str(42)"
+        },
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@coalesce(null, 'x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+        },
+        {
+          "adf_expression": "@empty(createArray())",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(len([]) == 0)"
+        },
+        {
+          "adf_expression": "@string(42)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "str(42)"
+        },
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@coalesce(null, 'x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+        },
+        {
+          "adf_expression": "@empty(createArray())",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(len([]) == 0)"
+        },
+        {
+          "adf_expression": "@string(42)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "str(42)"
+        },
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@coalesce(null, 'x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+        },
+        {
+          "adf_expression": "@empty(createArray())",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(len([]) == 0)"
+        },
+        {
+          "adf_expression": "@string(42)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "str(42)"
+        },
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@coalesce(null, 'x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+        },
+        {
+          "adf_expression": "@empty(createArray())",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(len([]) == 0)"
+        },
+        {
+          "adf_expression": "@string(42)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "str(42)"
+        },
+        {
+          "adf_expression": "@length(createArray(1, 2, 3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "len([1, 2, 3])"
+        },
+        {
+          "adf_expression": "@first(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[0]"
+        },
+        {
+          "adf_expression": "@last(createArray('a', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "(['a', 'b'])[-1]"
+        },
+        {
+          "adf_expression": "@createArray('a', 'b', 'c')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "['a', 'b', 'c']"
+        },
+        {
+          "adf_expression": "@createArray(1, 2, 3)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "[1, 2, 3]"
+        },
+        {
+          "adf_expression": "@createArray('only_one')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "['only_one']"
+        },
+        {
+          "adf_expression": "@createArray('alpha', 'beta', 'gamma', 'delta')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "['alpha', 'beta', 'gamma', 'delta']"
+        },
+        {
+          "adf_expression": "@createArray(string(1), string(2), string(3))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "[str(1), str(2), str(3)]"
+        },
+        {
+          "adf_expression": "@createArray(true, false, true)",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "[True, False, True]"
+        },
+        {
+          "adf_expression": "@createArray(concat('item_', 'a'), concat('item_', 'b'))",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "[str('item_') + str('a'), str('item_') + str('b')]"
+        },
+        {
+          "adf_expression": "@createArray('x')",
+          "category": "collection",
+          "context": "if_condition",
+          "python_code": "['x']"
+        }
+      ],
+      "sample_failures": [],
+      "total": 41
+    },
+    "datetime,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 33,
+      "placeholder_count": 0,
+      "resolved": 33,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        },
+        {
+          "adf_expression": "@utcNow()",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_utc_now()"
+        },
+        {
+          "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+          "category": "datetime",
+          "context": "if_condition",
+          "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+        }
+      ],
+      "sample_failures": [],
+      "total": 33
+    },
+    "logical,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 20,
+      "placeholder_count": 0,
+      "resolved": 33,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@equals(1, 1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(1 == 1)"
+        },
+        {
+          "adf_expression": "@greater(3, 2)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(3 > 2)"
+        },
+        {
+          "adf_expression": "@less(2, 3)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(2 < 3)"
+        },
+        {
+          "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 == 1) and (3 > 2))"
+        },
+        {
+          "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 < 0) or ('x' == 'x'))"
+        },
+        {
+          "adf_expression": "@not(false)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(not False)"
+        },
+        {
+          "adf_expression": "@bool(1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "bool(1)"
+        },
+        {
+          "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "('yes' if (1 == 1) else 'no')"
+        },
+        {
+          "adf_expression": "@equals(1, 1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(1 == 1)"
+        },
+        {
+          "adf_expression": "@greater(3, 2)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(3 > 2)"
+        },
+        {
+          "adf_expression": "@less(2, 3)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(2 < 3)"
+        },
+        {
+          "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 == 1) and (3 > 2))"
+        },
+        {
+          "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 < 0) or ('x' == 'x'))"
+        },
+        {
+          "adf_expression": "@not(false)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(not False)"
+        },
+        {
+          "adf_expression": "@bool(1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "bool(1)"
+        },
+        {
+          "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "('yes' if (1 == 1) else 'no')"
+        },
+        {
+          "adf_expression": "@equals(1, 1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(1 == 1)"
+        },
+        {
+          "adf_expression": "@greater(3, 2)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(3 > 2)"
+        },
+        {
+          "adf_expression": "@less(2, 3)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(2 < 3)"
+        },
+        {
+          "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 == 1) and (3 > 2))"
+        },
+        {
+          "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 < 0) or ('x' == 'x'))"
+        },
+        {
+          "adf_expression": "@not(false)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(not False)"
+        },
+        {
+          "adf_expression": "@bool(1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "bool(1)"
+        },
+        {
+          "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "('yes' if (1 == 1) else 'no')"
+        },
+        {
+          "adf_expression": "@equals(1, 1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(1 == 1)"
+        },
+        {
+          "adf_expression": "@greater(3, 2)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(3 > 2)"
+        },
+        {
+          "adf_expression": "@less(2, 3)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(2 < 3)"
+        },
+        {
+          "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 == 1) and (3 > 2))"
+        },
+        {
+          "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((1 < 0) or ('x' == 'x'))"
+        },
+        {
+          "adf_expression": "@not(false)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(not False)"
+        },
+        {
+          "adf_expression": "@bool(1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "bool(1)"
+        },
+        {
+          "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "('yes' if (1 == 1) else 'no')"
+        },
+        {
+          "adf_expression": "@equals(1, 1)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(1 == 1)"
+        }
+      ],
+      "sample_failures": [],
+      "total": 33
+    },
+    "math,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 34,
+      "placeholder_count": 0,
+      "resolved": 34,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@add(1, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(1 + 2)"
+        },
+        {
+          "adf_expression": "@sub(10, 4)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(10 - 4)"
+        },
+        {
+          "adf_expression": "@mul(3, 7)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(3 * 7)"
+        },
+        {
+          "adf_expression": "@div(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 // 2)"
+        },
+        {
+          "adf_expression": "@mod(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 % 2)"
+        },
+        {
+          "adf_expression": "@int('42')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "int('42')"
+        },
+        {
+          "adf_expression": "@float('3.14')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "float('3.14')"
+        },
+        {
+          "adf_expression": "@add(1, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(1 + 2)"
+        },
+        {
+          "adf_expression": "@sub(10, 4)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(10 - 4)"
+        },
+        {
+          "adf_expression": "@mul(3, 7)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(3 * 7)"
+        },
+        {
+          "adf_expression": "@div(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 // 2)"
+        },
+        {
+          "adf_expression": "@mod(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 % 2)"
+        },
+        {
+          "adf_expression": "@int('42')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "int('42')"
+        },
+        {
+          "adf_expression": "@float('3.14')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "float('3.14')"
+        },
+        {
+          "adf_expression": "@add(1, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(1 + 2)"
+        },
+        {
+          "adf_expression": "@sub(10, 4)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(10 - 4)"
+        },
+        {
+          "adf_expression": "@mul(3, 7)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(3 * 7)"
+        },
+        {
+          "adf_expression": "@div(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 // 2)"
+        },
+        {
+          "adf_expression": "@mod(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 % 2)"
+        },
+        {
+          "adf_expression": "@int('42')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "int('42')"
+        },
+        {
+          "adf_expression": "@float('3.14')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "float('3.14')"
+        },
+        {
+          "adf_expression": "@add(1, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(1 + 2)"
+        },
+        {
+          "adf_expression": "@sub(10, 4)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(10 - 4)"
+        },
+        {
+          "adf_expression": "@mul(3, 7)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(3 * 7)"
+        },
+        {
+          "adf_expression": "@div(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 // 2)"
+        },
+        {
+          "adf_expression": "@mod(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 % 2)"
+        },
+        {
+          "adf_expression": "@int('42')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "int('42')"
+        },
+        {
+          "adf_expression": "@float('3.14')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "float('3.14')"
+        },
+        {
+          "adf_expression": "@add(1, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(1 + 2)"
+        },
+        {
+          "adf_expression": "@sub(10, 4)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(10 - 4)"
+        },
+        {
+          "adf_expression": "@mul(3, 7)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(3 * 7)"
+        },
+        {
+          "adf_expression": "@div(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 // 2)"
+        },
+        {
+          "adf_expression": "@mod(9, 2)",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "(9 % 2)"
+        },
+        {
+          "adf_expression": "@int('42')",
+          "category": "math",
+          "context": "if_condition",
+          "python_code": "int('42')"
+        }
+      ],
+      "sample_failures": [],
+      "total": 34
+    },
+    "nested,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 33,
+      "placeholder_count": 0,
+      "resolved": 33,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        },
+        {
+          "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+        },
+        {
+          "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+        },
+        {
+          "adf_expression": "@string(length(split('a-b-c', '-')))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "str(len(str('a-b-c').split('-')))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 33
+    },
+    "string,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 34,
+      "placeholder_count": 0,
+      "resolved": 34,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@concat('hello', 'world')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('hello') + str('world')"
+        },
+        {
+          "adf_expression": "@replace('abc', 'a', 'z')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abc').replace('a', 'z')"
+        },
+        {
+          "adf_expression": "@toUpper('abc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('abc') is None else str('abc').upper())"
+        },
+        {
+          "adf_expression": "@toLower('ABC')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+        },
+        {
+          "adf_expression": "@trim('  hi  ')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+        },
+        {
+          "adf_expression": "@substring('abcdef', 1, 3)",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcdef')[1:1 + 3]"
+        },
+        {
+          "adf_expression": "@indexOf('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').find('bc')"
+        },
+        {
+          "adf_expression": "@startsWith('abcd', 'ab')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').startswith('ab')"
+        },
+        {
+          "adf_expression": "@endsWith('abcd', 'cd')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').endswith('cd')"
+        },
+        {
+          "adf_expression": "@contains('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "('bc' in str('abcd'))"
+        },
+        {
+          "adf_expression": "@concat('hello', 'world')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('hello') + str('world')"
+        },
+        {
+          "adf_expression": "@replace('abc', 'a', 'z')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abc').replace('a', 'z')"
+        },
+        {
+          "adf_expression": "@toUpper('abc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('abc') is None else str('abc').upper())"
+        },
+        {
+          "adf_expression": "@toLower('ABC')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+        },
+        {
+          "adf_expression": "@trim('  hi  ')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+        },
+        {
+          "adf_expression": "@substring('abcdef', 1, 3)",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcdef')[1:1 + 3]"
+        },
+        {
+          "adf_expression": "@indexOf('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').find('bc')"
+        },
+        {
+          "adf_expression": "@startsWith('abcd', 'ab')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').startswith('ab')"
+        },
+        {
+          "adf_expression": "@endsWith('abcd', 'cd')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').endswith('cd')"
+        },
+        {
+          "adf_expression": "@contains('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "('bc' in str('abcd'))"
+        },
+        {
+          "adf_expression": "@concat('hello', 'world')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('hello') + str('world')"
+        },
+        {
+          "adf_expression": "@replace('abc', 'a', 'z')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abc').replace('a', 'z')"
+        },
+        {
+          "adf_expression": "@toUpper('abc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('abc') is None else str('abc').upper())"
+        },
+        {
+          "adf_expression": "@toLower('ABC')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+        },
+        {
+          "adf_expression": "@trim('  hi  ')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+        },
+        {
+          "adf_expression": "@substring('abcdef', 1, 3)",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcdef')[1:1 + 3]"
+        },
+        {
+          "adf_expression": "@indexOf('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').find('bc')"
+        },
+        {
+          "adf_expression": "@startsWith('abcd', 'ab')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').startswith('ab')"
+        },
+        {
+          "adf_expression": "@endsWith('abcd', 'cd')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abcd').endswith('cd')"
+        },
+        {
+          "adf_expression": "@contains('abcd', 'bc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "('bc' in str('abcd'))"
+        },
+        {
+          "adf_expression": "@concat('hello', 'world')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('hello') + str('world')"
+        },
+        {
+          "adf_expression": "@replace('abc', 'a', 'z')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "str('abc').replace('a', 'z')"
+        },
+        {
+          "adf_expression": "@toUpper('abc')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('abc') is None else str('abc').upper())"
+        },
+        {
+          "adf_expression": "@toLower('ABC')",
+          "category": "string",
+          "context": "if_condition",
+          "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+        }
+      ],
+      "sample_failures": [],
+      "total": 34
+    }
+  },
+  "by_context": {
+    "if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 195,
+      "placeholder_count": 0,
+      "resolved": 208,
+      "total": 208
+    }
+  },
+  "contexts_run": [
+    "if_condition"
+  ],
+  "resolved_pairs": [
+    {
+      "adf_expression": "@concat('hello', 'world')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('hello') + str('world')"
+    },
+    {
+      "adf_expression": "@replace('abc', 'a', 'z')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abc').replace('a', 'z')"
+    },
+    {
+      "adf_expression": "@toUpper('abc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('abc') is None else str('abc').upper())"
+    },
+    {
+      "adf_expression": "@toLower('ABC')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+    },
+    {
+      "adf_expression": "@trim('  hi  ')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+    },
+    {
+      "adf_expression": "@substring('abcdef', 1, 3)",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcdef')[1:1 + 3]"
+    },
+    {
+      "adf_expression": "@indexOf('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').find('bc')"
+    },
+    {
+      "adf_expression": "@startsWith('abcd', 'ab')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').startswith('ab')"
+    },
+    {
+      "adf_expression": "@endsWith('abcd', 'cd')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').endswith('cd')"
+    },
+    {
+      "adf_expression": "@contains('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "('bc' in str('abcd'))"
+    },
+    {
+      "adf_expression": "@concat('hello', 'world')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('hello') + str('world')"
+    },
+    {
+      "adf_expression": "@replace('abc', 'a', 'z')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abc').replace('a', 'z')"
+    },
+    {
+      "adf_expression": "@toUpper('abc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('abc') is None else str('abc').upper())"
+    },
+    {
+      "adf_expression": "@toLower('ABC')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+    },
+    {
+      "adf_expression": "@trim('  hi  ')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+    },
+    {
+      "adf_expression": "@substring('abcdef', 1, 3)",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcdef')[1:1 + 3]"
+    },
+    {
+      "adf_expression": "@indexOf('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').find('bc')"
+    },
+    {
+      "adf_expression": "@startsWith('abcd', 'ab')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').startswith('ab')"
+    },
+    {
+      "adf_expression": "@endsWith('abcd', 'cd')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').endswith('cd')"
+    },
+    {
+      "adf_expression": "@contains('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "('bc' in str('abcd'))"
+    },
+    {
+      "adf_expression": "@concat('hello', 'world')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('hello') + str('world')"
+    },
+    {
+      "adf_expression": "@replace('abc', 'a', 'z')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abc').replace('a', 'z')"
+    },
+    {
+      "adf_expression": "@toUpper('abc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('abc') is None else str('abc').upper())"
+    },
+    {
+      "adf_expression": "@toLower('ABC')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+    },
+    {
+      "adf_expression": "@trim('  hi  ')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('  hi  ') is None else str('  hi  ').strip())"
+    },
+    {
+      "adf_expression": "@substring('abcdef', 1, 3)",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcdef')[1:1 + 3]"
+    },
+    {
+      "adf_expression": "@indexOf('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').find('bc')"
+    },
+    {
+      "adf_expression": "@startsWith('abcd', 'ab')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').startswith('ab')"
+    },
+    {
+      "adf_expression": "@endsWith('abcd', 'cd')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abcd').endswith('cd')"
+    },
+    {
+      "adf_expression": "@contains('abcd', 'bc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "('bc' in str('abcd'))"
+    },
+    {
+      "adf_expression": "@concat('hello', 'world')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('hello') + str('world')"
+    },
+    {
+      "adf_expression": "@replace('abc', 'a', 'z')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "str('abc').replace('a', 'z')"
+    },
+    {
+      "adf_expression": "@toUpper('abc')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('abc') is None else str('abc').upper())"
+    },
+    {
+      "adf_expression": "@toLower('ABC')",
+      "category": "string",
+      "context": "if_condition",
+      "python_code": "(None if ('ABC') is None else str('ABC').lower())"
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(1 + 2)"
+    },
+    {
+      "adf_expression": "@sub(10, 4)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(10 - 4)"
+    },
+    {
+      "adf_expression": "@mul(3, 7)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(3 * 7)"
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 // 2)"
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 % 2)"
+    },
+    {
+      "adf_expression": "@int('42')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "int('42')"
+    },
+    {
+      "adf_expression": "@float('3.14')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "float('3.14')"
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(1 + 2)"
+    },
+    {
+      "adf_expression": "@sub(10, 4)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(10 - 4)"
+    },
+    {
+      "adf_expression": "@mul(3, 7)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(3 * 7)"
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 // 2)"
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 % 2)"
+    },
+    {
+      "adf_expression": "@int('42')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "int('42')"
+    },
+    {
+      "adf_expression": "@float('3.14')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "float('3.14')"
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(1 + 2)"
+    },
+    {
+      "adf_expression": "@sub(10, 4)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(10 - 4)"
+    },
+    {
+      "adf_expression": "@mul(3, 7)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(3 * 7)"
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 // 2)"
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 % 2)"
+    },
+    {
+      "adf_expression": "@int('42')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "int('42')"
+    },
+    {
+      "adf_expression": "@float('3.14')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "float('3.14')"
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(1 + 2)"
+    },
+    {
+      "adf_expression": "@sub(10, 4)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(10 - 4)"
+    },
+    {
+      "adf_expression": "@mul(3, 7)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(3 * 7)"
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 // 2)"
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 % 2)"
+    },
+    {
+      "adf_expression": "@int('42')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "int('42')"
+    },
+    {
+      "adf_expression": "@float('3.14')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "float('3.14')"
+    },
+    {
+      "adf_expression": "@add(1, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(1 + 2)"
+    },
+    {
+      "adf_expression": "@sub(10, 4)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(10 - 4)"
+    },
+    {
+      "adf_expression": "@mul(3, 7)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(3 * 7)"
+    },
+    {
+      "adf_expression": "@div(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 // 2)"
+    },
+    {
+      "adf_expression": "@mod(9, 2)",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "(9 % 2)"
+    },
+    {
+      "adf_expression": "@int('42')",
+      "category": "math",
+      "context": "if_condition",
+      "python_code": "int('42')"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@utcNow()",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_utc_now()"
+    },
+    {
+      "adf_expression": "@formatDateTime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')",
+      "category": "datetime",
+      "context": "if_condition",
+      "python_code": "_wkmigrate_format_datetime('2024-01-01T00:00:00Z', 'yyyy-MM-dd')"
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(1 == 1)"
+    },
+    {
+      "adf_expression": "@greater(3, 2)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(3 > 2)"
+    },
+    {
+      "adf_expression": "@less(2, 3)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(2 < 3)"
+    },
+    {
+      "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 == 1) and (3 > 2))"
+    },
+    {
+      "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 < 0) or ('x' == 'x'))"
+    },
+    {
+      "adf_expression": "@not(false)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(not False)"
+    },
+    {
+      "adf_expression": "@bool(1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "bool(1)"
+    },
+    {
+      "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "('yes' if (1 == 1) else 'no')"
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(1 == 1)"
+    },
+    {
+      "adf_expression": "@greater(3, 2)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(3 > 2)"
+    },
+    {
+      "adf_expression": "@less(2, 3)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(2 < 3)"
+    },
+    {
+      "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 == 1) and (3 > 2))"
+    },
+    {
+      "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 < 0) or ('x' == 'x'))"
+    },
+    {
+      "adf_expression": "@not(false)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(not False)"
+    },
+    {
+      "adf_expression": "@bool(1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "bool(1)"
+    },
+    {
+      "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "('yes' if (1 == 1) else 'no')"
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(1 == 1)"
+    },
+    {
+      "adf_expression": "@greater(3, 2)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(3 > 2)"
+    },
+    {
+      "adf_expression": "@less(2, 3)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(2 < 3)"
+    },
+    {
+      "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 == 1) and (3 > 2))"
+    },
+    {
+      "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 < 0) or ('x' == 'x'))"
+    },
+    {
+      "adf_expression": "@not(false)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(not False)"
+    },
+    {
+      "adf_expression": "@bool(1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "bool(1)"
+    },
+    {
+      "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "('yes' if (1 == 1) else 'no')"
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(1 == 1)"
+    },
+    {
+      "adf_expression": "@greater(3, 2)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(3 > 2)"
+    },
+    {
+      "adf_expression": "@less(2, 3)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(2 < 3)"
+    },
+    {
+      "adf_expression": "@and(equals(1, 1), greater(3, 2))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 == 1) and (3 > 2))"
+    },
+    {
+      "adf_expression": "@or(less(1, 0), equals('x', 'x'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((1 < 0) or ('x' == 'x'))"
+    },
+    {
+      "adf_expression": "@not(false)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(not False)"
+    },
+    {
+      "adf_expression": "@bool(1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "bool(1)"
+    },
+    {
+      "adf_expression": "@if(equals(1, 1), 'yes', 'no')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "('yes' if (1 == 1) else 'no')"
+    },
+    {
+      "adf_expression": "@equals(1, 1)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(1 == 1)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+    },
+    {
+      "adf_expression": "@empty(createArray())",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(len([]) == 0)"
+    },
+    {
+      "adf_expression": "@string(42)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "str(42)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+    },
+    {
+      "adf_expression": "@empty(createArray())",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(len([]) == 0)"
+    },
+    {
+      "adf_expression": "@string(42)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "str(42)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+    },
+    {
+      "adf_expression": "@empty(createArray())",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(len([]) == 0)"
+    },
+    {
+      "adf_expression": "@string(42)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "str(42)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+    },
+    {
+      "adf_expression": "@empty(createArray())",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(len([]) == 0)"
+    },
+    {
+      "adf_expression": "@string(42)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "str(42)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@coalesce(null, 'x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "next((v for v in [None, 'x'] if v is not None), None)"
+    },
+    {
+      "adf_expression": "@empty(createArray())",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(len([]) == 0)"
+    },
+    {
+      "adf_expression": "@string(42)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "str(42)"
+    },
+    {
+      "adf_expression": "@length(createArray(1, 2, 3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "len([1, 2, 3])"
+    },
+    {
+      "adf_expression": "@first(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[0]"
+    },
+    {
+      "adf_expression": "@last(createArray('a', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "(['a', 'b'])[-1]"
+    },
+    {
+      "adf_expression": "@createArray('a', 'b', 'c')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "['a', 'b', 'c']"
+    },
+    {
+      "adf_expression": "@createArray(1, 2, 3)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "[1, 2, 3]"
+    },
+    {
+      "adf_expression": "@createArray('only_one')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "['only_one']"
+    },
+    {
+      "adf_expression": "@createArray('alpha', 'beta', 'gamma', 'delta')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "['alpha', 'beta', 'gamma', 'delta']"
+    },
+    {
+      "adf_expression": "@createArray(string(1), string(2), string(3))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "[str(1), str(2), str(3)]"
+    },
+    {
+      "adf_expression": "@createArray(true, false, true)",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "[True, False, True]"
+    },
+    {
+      "adf_expression": "@createArray(concat('item_', 'a'), concat('item_', 'b'))",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "[str('item_') + str('a'), str('item_') + str('b')]"
+    },
+    {
+      "adf_expression": "@createArray('x')",
+      "category": "collection",
+      "context": "if_condition",
+      "python_code": "['x']"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    },
+    {
+      "adf_expression": "@concat(toUpper('x'), string(add(1, 2)))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str((None if ('x') is None else str('x').upper())) + str(str((1 + 2)))"
+    },
+    {
+      "adf_expression": "@if(equals(mod(5, 2), 1), 'odd', 'even')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "('odd' if ((5 % 2) == 1) else 'even')"
+    },
+    {
+      "adf_expression": "@string(length(split('a-b-c', '-')))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "str(len(str('a-b-c').split('-')))"
+    }
+  ]
+}

--- a/dev/results/step-7-vista-cliente/crp0001-batch-2026-04-23.stderr
+++ b/dev/results/step-7-vista-cliente/crp0001-batch-2026-04-23.stderr
@@ -1,6 +1,6 @@
 warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
 ╭───────────────────── Traceback (most recent call last) ──────────────────────╮
-│ /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator/src/lake │
+│ <REPO>/src/lake │
 │ flow_migration_validator/cli.py:291 in batch_command                         │
 │                                                                              │
 │    288 ) -> None:                                                            │
@@ -11,7 +11,7 @@ warning: No `requires-python` value found in the workspace. Defaulting to `>=3.1
 │    293 │   _emit(report.to_dict())                                           │
 │    294                                                                       │
 │                                                                              │
-│ /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator/src/lake │
+│ <REPO>/src/lake │
 │ flow_migration_validator/synthetic/ground_truth.py:34 in from_json           │
 │                                                                              │
 │    31 │   │   """Load a previously generated suite from disk."""             │

--- a/dev/results/step-7-vista-cliente/crp0001-batch-2026-04-23.stderr
+++ b/dev/results/step-7-vista-cliente/crp0001-batch-2026-04-23.stderr
@@ -1,0 +1,25 @@
+warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+╭───────────────────── Traceback (most recent call last) ──────────────────────╮
+│ /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator/src/lake │
+│ flow_migration_validator/cli.py:291 in batch_command                         │
+│                                                                              │
+│    288 ) -> None:                                                            │
+│    289 │   """Evaluate a converter against a golden-set suite."""            │
+│    290 │   _auto_configure()                                                 │
+│ ❱  291 │   suite = GroundTruthSuite.from_json(str(golden_set))               │
+│    292 │   report = evaluate_batch(suite, _CONVERT_FN, threshold=threshold)  │
+│    293 │   _emit(report.to_dict())                                           │
+│    294                                                                       │
+│                                                                              │
+│ /Users/miguel.peralvo/Code/adf_to_lakeflow_jobs_migration_validator/src/lake │
+│ flow_migration_validator/synthetic/ground_truth.py:34 in from_json           │
+│                                                                              │
+│    31 │   │   """Load a previously generated suite from disk."""             │
+│    32 │   │   with open(path, encoding="utf-8") as handle:                   │
+│    33 │   │   │   payload = json.load(handle)                                │
+│ ❱  34 │   │   pipelines = tuple(_synthetic_pipeline_from_dict(item) for item │
+│    35 │   │   return cls(pipelines=pipelines)                                │
+│    36 │                                                                      │
+│    37 │   def to_json(self, path: str) -> None:                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+KeyError: 'pipelines'

--- a/dev/results/step-7-vista-cliente/step7-kpi-summary-2026-04-23.json
+++ b/dev/results/step-7-vista-cliente/step7-kpi-summary-2026-04-23.json
@@ -1,0 +1,44 @@
+{
+  "wkmigrate_sha": "cfb49e6",
+  "baseline_x1": 0.8317,
+  "crp0001_replay_x1": 1.0,
+  "vista_cliente_x1": 1.0,
+  "delta_crp_vs_baseline": 0.1683,
+  "delta_vc_vs_baseline": 0.1683,
+  "crp_within_5pct": false,
+  "x6_per_category": {
+    "collection": {
+      "crp_cov": 1.0,
+      "vc_cov": null
+    },
+    "datetime": {
+      "crp_cov": 1.0,
+      "vc_cov": null
+    },
+    "logical": {
+      "crp_cov": 1.0,
+      "vc_cov": 1.0
+    },
+    "math": {
+      "crp_cov": 1.0,
+      "vc_cov": null
+    },
+    "nested": {
+      "crp_cov": 1.0,
+      "vc_cov": 1.0
+    },
+    "string": {
+      "crp_cov": 1.0,
+      "vc_cov": null
+    }
+  },
+  "vc_all_contexts": {
+    "copy_query": 1.0,
+    "for_each": 0.0,
+    "if_condition": 1.0,
+    "lookup_query": 1.0,
+    "notebook_base_param": 1.0,
+    "set_variable": 1.0,
+    "web_body": 1.0
+  }
+}

--- a/dev/results/step-7-vista-cliente/sweep-all-contexts-2026-04-23.json
+++ b/dev/results/step-7-vista-cliente/sweep-all-contexts-2026-04-23.json
@@ -1,0 +1,14706 @@
+{
+  "by_cell": {
+    "logical,copy_query": {
+      "error_count": 0,
+      "not_translatable_count": 12,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "copy_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "logical,for_each": {
+      "error_count": 0,
+      "not_translatable_count": 25,
+      "placeholder_count": 25,
+      "resolved": 0,
+      "sample_failures": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "activity_name": "foreach",
+              "activity_type": "ForEach",
+              "message": "variables('continue') producer not in context cache; emitting best-effort taskKey='set_variable_continue'. Likely the SetVariable lives inside a multi-activity ForEach \u2014 the resulting lookup will fail at runtime. See dev/step-3-variables-fanin.md for the fan-in design.",
+              "property": "variables"
+            },
+            {
+              "activity_name": "foreach",
+              "activity_type": "ForEach",
+              "message": "variables('testPassed') producer not in context cache; emitting best-effort taskKey='set_variable_testPassed'. Likely the SetVariable lives inside a multi-activity ForEach \u2014 the resulting lookup will fail at runtime. See dev/step-3-variables-fanin.md for the fan-in design.",
+              "property": "variables"
+            },
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "activity_name": "foreach",
+              "activity_type": "ForEach",
+              "message": "variables('continue') producer not in context cache; emitting best-effort taskKey='set_variable_continue'. Likely the SetVariable lives inside a multi-activity ForEach \u2014 the resulting lookup will fail at runtime. See dev/step-3-variables-fanin.md for the fan-in design.",
+              "property": "variables"
+            },
+            {
+              "activity_name": "foreach",
+              "activity_type": "ForEach",
+              "message": "variables('testPassed') producer not in context cache; emitting best-effort taskKey='set_variable_testPassed'. Likely the SetVariable lives inside a multi-activity ForEach \u2014 the resulting lookup will fail at runtime. See dev/step-3-variables-fanin.md for the fan-in design.",
+              "property": "variables"
+            },
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        }
+      ],
+      "total": 25
+    },
+    "logical,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 19,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "logical,lookup_query": {
+      "error_count": 0,
+      "not_translatable_count": 25,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "lookup_query",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "logical,notebook_base_param": {
+      "error_count": 0,
+      "not_translatable_count": 12,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "notebook_base_param",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "logical,set_variable": {
+      "error_count": 0,
+      "not_translatable_count": 12,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "set_variable",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "logical,web_body": {
+      "error_count": 0,
+      "not_translatable_count": 12,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "web_body",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "nested,copy_query": {
+      "error_count": 0,
+      "not_translatable_count": 24,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "copy_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    },
+    "nested,for_each": {
+      "error_count": 0,
+      "not_translatable_count": 175,
+      "placeholder_count": 175,
+      "resolved": 0,
+      "sample_failures": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "expected_python": null,
+          "not_translatable": [
+            {
+              "kind": "placeholder_activity",
+              "message": "Activity 'foreach' (type: ForEach) was substituted with a placeholder DatabricksNotebookActivity (wkmigrate did not recognise the source ADF activity type).",
+              "original_activity_type": "ForEach",
+              "property": "foreach",
+              "task_key": "foreach"
+            }
+          ]
+        }
+      ],
+      "total": 175
+    },
+    "nested,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 175,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    },
+    "nested,lookup_query": {
+      "error_count": 0,
+      "not_translatable_count": 175,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "lookup_query",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    },
+    "nested,notebook_base_param": {
+      "error_count": 0,
+      "not_translatable_count": 24,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "notebook_base_param",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    },
+    "nested,set_variable": {
+      "error_count": 0,
+      "not_translatable_count": 24,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "set_variable",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    },
+    "nested,web_body": {
+      "error_count": 0,
+      "not_translatable_count": 24,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "web_body",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    }
+  },
+  "by_context": {
+    "copy_query": {
+      "error_count": 0,
+      "not_translatable_count": 36,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    },
+    "for_each": {
+      "error_count": 0,
+      "not_translatable_count": 200,
+      "placeholder_count": 200,
+      "resolved": 0,
+      "total": 200
+    },
+    "if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 194,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    },
+    "lookup_query": {
+      "error_count": 0,
+      "not_translatable_count": 200,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    },
+    "notebook_base_param": {
+      "error_count": 0,
+      "not_translatable_count": 36,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    },
+    "set_variable": {
+      "error_count": 0,
+      "not_translatable_count": 36,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    },
+    "web_body": {
+      "error_count": 0,
+      "not_translatable_count": 36,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    }
+  },
+  "contexts_run": [
+    "set_variable",
+    "notebook_base_param",
+    "if_condition",
+    "for_each",
+    "web_body",
+    "lookup_query",
+    "copy_query"
+  ],
+  "resolved_pairs": [
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "set_variable",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "notebook_base_param",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "web_body",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "lookup_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "copy_query",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "set_variable",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "notebook_base_param",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "web_body",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "lookup_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "copy_query",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    }
+  ]
+}

--- a/dev/results/step-7-vista-cliente/sweep-if-condition-2026-04-23.json
+++ b/dev/results/step-7-vista-cliente/sweep-if-condition-2026-04-23.json
@@ -1,0 +1,2438 @@
+{
+  "by_cell": {
+    "logical,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 19,
+      "placeholder_count": 0,
+      "resolved": 25,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+        },
+        {
+          "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.config,' ')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('config') == ' ')"
+        },
+        {
+          "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+        },
+        {
+          "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+        },
+        {
+          "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+        },
+        {
+          "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+        },
+        {
+          "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+          "category": "logical",
+          "context": "if_condition",
+          "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 25
+    },
+    "nested,if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 175,
+      "placeholder_count": 0,
+      "resolved": 175,
+      "resolved_pairs": [
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@variables('continue')",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.enable",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('enable')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@pipeline().parameters.debug",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "dbutils.widgets.get('debug')"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        },
+        {
+          "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+          "category": "nested",
+          "context": "if_condition",
+          "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+        }
+      ],
+      "sample_failures": [],
+      "total": 175
+    }
+  },
+  "by_context": {
+    "if_condition": {
+      "error_count": 0,
+      "not_translatable_count": 194,
+      "placeholder_count": 0,
+      "resolved": 200,
+      "total": 200
+    }
+  },
+  "contexts_run": [
+    "if_condition"
+  ],
+  "resolved_pairs": [
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if ((int(dbutils.widgets.get('escenario')) == 2) and (int(dbutils.jobs.taskValues.get(taskKey='set_variable_max_periodo', key='max_periodo')) < int(dbutils.widgets.get('periodo')))) else False)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_ees', key='ejecuciones_ees') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.jobs.taskValues.get(taskKey='set_variable_esCuartoDiaHabil', key='esCuartoDiaHabil') == 'True') else False)"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_gen_trn_t_f_manuales_movil_portugal', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='cli0010_nb_prc_trn_t_ret_manuales', key='result')['runOutput']"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones_vvdd', key='ejecuciones_vvdd') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_escenario', key='escenario') == 'RE') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(False if (dbutils.jobs.taskValues.get(taskKey='set_variable_ejecuciones', key='ejecuciones') == '') else True)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('negocio') == 'ALL') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (dbutils.widgets.get('parentUid') == None))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('enable')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if ((dbutils.widgets.get('escenario') == 'pa') or (dbutils.widgets.get('escenario') == 'real')) else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(True if (dbutils.widgets.get('escenario') == 'PA') else False)"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "dbutils.widgets.get('debug')"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "context": "if_condition",
+      "python_code": "(not (len(dbutils.widgets.get('parentUid')) == 0))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_nonSkipCondition', key='nonSkipCondition'))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and (not (next((v for v in [((item or {}).get('test') or {}).get('targets_init'), '[]'] if v is not None), None) == '[]')))"
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue') and dbutils.jobs.taskValues.get(taskKey='set_variable_testPassed', key='testPassed'))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('configNotebook') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('config') == ' ')"
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(dbutils.widgets.get('nivel') == 'ERROR')"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == '') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'RE')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or (dbutils.widgets.get('escenario') == 'EST')))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'EST') or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA'))))))"
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "(((dbutils.widgets.get('applicationName') == '') or (len(dbutils.widgets.get('applicationName')) == 0)) or (dbutils.widgets.get('applicationName') == '@pipeline().parameters.applicationName'))"
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((dbutils.widgets.get('escenario') == ' ') or ((len(dbutils.widgets.get('escenario')) == 0) or ((dbutils.widgets.get('escenario') == 'PA') or ((dbutils.widgets.get('escenario') == 'UPA') or (dbutils.widgets.get('escenario') == 'PA-UPA')))))"
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((not (len(dbutils.widgets.get('message')) == 0)) and (str(str(dbutils.widgets.get('message'))).replace(\"'\", '') in str(json.loads(dbutils.jobs.taskValues.get(taskKey='set_variable_messageMap', key='messageMap')))))"
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "context": "if_condition",
+      "python_code": "((((((item)['type'] == 'NOTEBOOK') or ((item)['type'] == 'SIMPLE')) or ((item)['type'] == 'DELTA')) and dbutils.widgets.get('testing')) and dbutils.jobs.taskValues.get(taskKey='set_variable_continue', key='continue'))"
+    }
+  ]
+}

--- a/golden_sets/vista_cliente_expressions.json
+++ b/golden_sets/vista_cliente_expressions.json
@@ -1,0 +1,2224 @@
+{
+  "count": 200,
+  "origin": "vista_cliente_if_condition_sweep_2026_04_23",
+  "corpus": "/Users/miguel.peralvo/Downloads/DataFactory/pipeline",
+  "sampling": {
+    "seed": 42,
+    "floor_per_vc_category": 12,
+    "total_target": 200,
+    "strategy": "stratified_by_vc_category_with_floor_then_proportional_fill"
+  },
+  "vc_to_canonical_mapping": {
+    "compound_and": "logical",
+    "compound_or": "logical",
+    "nested_predicate": "logical",
+    "equals_binary": "logical",
+    "contains_intersection_empty": "collection",
+    "concat_string": "string",
+    "variables_ref": "nested",
+    "bare_activity_output": "nested",
+    "pipeline_param_ref": "nested"
+  },
+  "expressions": [
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_centro_cos_cpred",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_may",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_tot",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_end_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_tot",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_camp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_pt_dim_pos7",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_jerarquias",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_trn_gen_e_t_l_prod_cli",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_conceptos",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_pocess_totaldg_cliente_icv",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_min",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_switch2_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/init_tests",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_switch_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_internal",
+        "activity_name": "ForEach1/continue",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_internal",
+        "activity_name": "ForEach1/continue",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_switch_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('nonSkipCondition'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    not(equals(coalesce(item()?.test?.targets_init, '[]'), '[]')))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/init_tests",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(variables('continue'), variables('testPassed'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_switch2_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_log_aria",
+        "activity_name": "SetMessageFromDictIfExists",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/tests",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(and(equals(int(pipeline().parameters.escenario), 2),less(int(variables('max_periodo')),int(pipeline().parameters.periodo))), true, false)\n\n",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_anl_edw_vistacliente",
+        "activity_name": "Condicional con max_periodo",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_cdg_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_nested_par_internal",
+        "activity_name": "Ejecucion Paralela/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_nested_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_ees'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_ees_automation",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_mmex_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_nested_par_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('esCuartoDiaHabil'),'True'), true, false)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_laae_business_day_orq",
+        "activity_name": "If esCuartoDiaHabil",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_nested_par_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_cmi_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_prc_anl_process_glp_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_sendmail_internal",
+        "activity_name": "sendMail",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_sendmail_internal",
+        "activity_name": "notebook",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_log",
+        "activity_name": "LogTypeConditionError",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.configNotebook,' ')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_sendmail_internal",
+        "activity_name": "notebook",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.config,' ')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_sendmail_internal",
+        "activity_name": "sendMail",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@equals(pipeline().parameters.nivel, 'ERROR')",
+      "category": "logical",
+      "vc_category": "equals_binary",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_log_aria",
+        "activity_name": "LogTypeConditionError",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,''),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'RE')\n))",
+      "category": "logical",
+      "vc_category": "compound_or",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_process_glp_mensual_seleccion_escenarios",
+        "activity_name": "Comprobador lanzamiento REAL",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nequals(pipeline().parameters.escenario,'EST')))",
+      "category": "logical",
+      "vc_category": "compound_or",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_prc_anl_process_glp_iterative",
+        "activity_name": "Busqueda rutas est",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'EST'),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n)))))",
+      "category": "logical",
+      "vc_category": "compound_or",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_process_glp_mensual_seleccion_escenarios",
+        "activity_name": "Comprobador lanzamiento EST PA UPA",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@or( \n    or(\n        equals(pipeline().parameters.applicationName, ''),\n        empty(pipeline().parameters.applicationName)\n    ),\n    equals(pipeline().parameters.applicationName, '@pipeline().parameters.applicationName')\n)",
+      "category": "logical",
+      "vc_category": "compound_or",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_sendMail",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@or(equals(pipeline().parameters.escenario,' '),\nor(empty(pipeline().parameters.escenario),\nor(equals(pipeline().parameters.escenario,'PA'),\nor(equals(pipeline().parameters.escenario,'UPA'),\nequals(pipeline().parameters.escenario,'PA-UPA')\n))))",
+      "category": "logical",
+      "vc_category": "compound_or",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_prc_anl_process_glp_iterative",
+        "activity_name": "Busqueda rutas pa",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_gen_trn_t_f_manuales_movil_portugal').output.runOutput\n",
+      "category": "nested",
+      "vc_category": "bare_activity_output",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_trn_gen_e_t_l_manualespt",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@activity('cli0010_nb_prc_trn_t_ret_manuales').output.runOutput",
+      "category": "nested",
+      "vc_category": "bare_activity_output",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_retail_v2",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_tot",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_pt_automation_for",
+        "activity_name": "ForEach1/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(not(empty(pipeline().parameters.message)),contains(json(variables('messageMap')), replace(string(pipeline().parameters.message), '''', '')))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_log",
+        "activity_name": "SetMessageFromDictIfExists",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_producto_lae",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_nested_internal",
+        "activity_name": "ForEach1/continue",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@and(\n    and(\n        or(\n            or(\n                equals(item().type, 'NOTEBOOK'), \n                equals(item().type, 'SIMPLE')),\n            equals(item().type, 'DELTA')),\n        pipeline().parameters.testing),\n    variables('continue'))",
+      "category": "logical",
+      "vc_category": "compound_and",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo_switch_internal",
+        "activity_name": "Ejecucion Paralela/tests",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_tot",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_retail_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_est",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_nested_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_conceptos",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones_vvdd'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_automation",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_produ_lae_txt",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_nested_internal",
+        "activity_name": "ForEach1/continue",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_retail_dim_jerarquia",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_cdg_automation_for",
+        "activity_name": "ForEach/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_pa_upa",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('escenario'), 'RE'), false, true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_cmi_automation_for",
+        "activity_name": "ForEach1/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_process_mae_negocios_totaldg",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_laae_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_maestros",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_nested_par_internal",
+        "activity_name": "Ejecucion Paralela/If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orquestador_fich",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@variables('continue')",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo_internal",
+        "activity_name": "Return error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_pet",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(variables('ejecuciones'), ''), false,true)",
+      "category": "nested",
+      "vc_category": "variables_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_pt_automation",
+        "activity_name": "Check if datos tabla de control",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_destinata_lae",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_producto_lae",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_edw_edw_edd",
+        "activity_name": "If ParentUId Ok",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_pa_upa",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_matgru_grupo_articulos",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_end_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_pet",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralDG_real",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_destinata_lae",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_mp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_update_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_pocess_totaldg_cliente_v2",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.negocio,'ALL'),true,false)",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_automatizacion_upa_main",
+        "activity_name": "Select ALL o Negocio",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_oficina_venta",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orq_control",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_retail_dim_jerarquia",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_gen_prd_lae",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_cliente",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_tot",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_maestros_laae",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_conceptos",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_mp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_may",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_cliente",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_produ_lae_txt",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_gesp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_productos",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orquestador_fich",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_uunn",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_tot",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_jerprod",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_cuotas_real_fich",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_tot",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_pet",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_process_mae_dim1_totaldg",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_ccanal",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_min",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_zonaventas",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_pet",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_anl_log_end_ok_aria",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_retail_dim_conceptos",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_trn_gen_e_t_l_prod_cli",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_destinatario",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_pet",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_min",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_update_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_pt_dim_pos7",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_mp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_cuotas_real_BW",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_may",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_may",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_pocess_totaldg_cliente_icv",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralMI_real",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_producto_txt",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_est",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_informes",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_gesp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_process_mae_concepto_totaldg",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orquestador_BW",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_real_v2",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_init_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_producto_txt",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralDG_pa_upa_est",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_camp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_cuotas_real_BW",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_arquetipo",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralMI_pa_upa_est",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_laae_real_v2",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_may",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralMI_pa_upa_est",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralDG_real",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_may",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_pocess_totaldg_cliente",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_camp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_cuotas_real_fich",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_pet",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_min",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_uunn",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(equals(pipeline().parameters.parentUid,null))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_anl_log_end_ko_aria",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_gen_x_producto",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_camp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario, 'PA'), true, false)",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_informes_pa_mvcv",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_process_mae_dim1_totaldg",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.enable",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_init_control",
+        "activity_name": "Control enabled",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_jerarquias",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orq_control",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_oficina_venta",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_matgru_grupo_articulos",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim2",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_mp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_destinatario",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_pet",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_pocess_totaldg_cliente_v2",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_edw_edw_edd",
+        "activity_name": "If ParentUId KO",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_gen_prd_lae",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(or(equals(pipeline().parameters.escenario,'pa'),equals(pipeline().parameters.escenario,'real')), true, false )",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_retail_v2",
+        "activity_name": "Si Real o PA ejecuta SDG y BPC-BFC",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_gen_x_producto",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_jerprod",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_maestros_laae",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_min",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_update_data",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_gesp",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_may",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_anl_process_mae_negocios_totaldg",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_marg_ven_may",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_eess_marg_ven_gesp",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_pet",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_arquetipo",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_conceptos",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_maestros",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_centralMI_real",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim1",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@if(equals(pipeline().parameters.escenario,'PA'), true,false)",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_informes_pa_upa",
+        "activity_name": "If Condition1",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_vvdd_update_data",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_retail_dim_conceptos",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@pipeline().parameters.debug",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "lakeh_a_pl_operational_log_debug",
+        "activity_name": "ConditionDebug",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_c_pl_main_orquestador_BW",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim_ccanal",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_vvdd_dim1",
+        "activity_name": "If ParentUId",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_tipocoste",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    },
+    {
+      "adf_expression": "@not(empty(pipeline().parameters.parentUid))",
+      "category": "nested",
+      "vc_category": "pipeline_param_ref",
+      "expected_python": null,
+      "source": {
+        "pipeline": "cli0010_a_pl_LAAE_ingest_grupoclientes",
+        "activity_name": "If ParentUId y error",
+        "depth": 0
+      }
+    }
+  ]
+}

--- a/golden_sets/vista_cliente_expressions.json
+++ b/golden_sets/vista_cliente_expressions.json
@@ -1,7 +1,7 @@
 {
   "count": 200,
   "origin": "vista_cliente_if_condition_sweep_2026_04_23",
-  "corpus": "/Users/miguel.peralvo/Downloads/DataFactory/pipeline",
+  "corpus": "<CORPUS_DIR>",
   "sampling": {
     "seed": 42,
     "floor_per_vc_category": 12,

--- a/scripts/compute_step7_kpis.py
+++ b/scripts/compute_step7_kpis.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Aggregate Step-7 sweep results into an X-series KPI table.
+
+Reads the VC and CRP0001 sweep JSONs produced by `lmv sweep-activity-contexts`
+and emits a Markdown table with X-1 / X-6 numbers per corpus + per category.
+
+Usage:
+    python scripts/compute_step7_kpis.py
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+RESULTS_DIR = Path("dev/results/step-7-vista-cliente")
+
+VC_IF = RESULTS_DIR / "sweep-if-condition-2026-04-23.json"
+VC_ALL = RESULTS_DIR / "sweep-all-contexts-2026-04-23.json"
+CRP_IF = RESULTS_DIR / "crp0001-baseline-replay-2026-04-23.json"
+
+
+def _coverage(cell: dict) -> float:
+    total = cell.get("total", 0)
+    resolved = cell.get("resolved", 0)
+    return resolved / total if total else 0.0
+
+
+def _per_category(sweep: dict, context: str = "if_condition") -> dict:
+    out: dict[str, dict] = {}
+    for key, cell in sweep.get("by_cell", {}).items():
+        cat, ctx = key.split(",", 1)
+        if ctx != context:
+            continue
+        out[cat] = cell
+    return out
+
+
+def main():
+    vc_if = json.loads(VC_IF.read_text())
+    vc_all = json.loads(VC_ALL.read_text())
+    crp_if = json.loads(CRP_IF.read_text())
+
+    # X-1: overall resolution ratio for if_condition
+    vc_context = vc_if["by_context"]["if_condition"]
+    crp_context = crp_if["by_context"]["if_condition"]
+
+    vc_x1 = _coverage(vc_context)
+    crp_x1 = _coverage(crp_context)
+    baseline_x1 = 0.8317  # from wkmigrate-issue-27-meta-kpis.md
+
+    # X-6: per-canonical-category resolution
+    vc_cat = _per_category(vc_if)
+    crp_cat = _per_category(crp_if)
+
+    # Secondary: VC all-contexts
+    vc_all_ctx = vc_all.get("by_context", {})
+
+    out = []
+    out.append("# Step 7 — Vista Cliente Sweep KPI Table\n")
+    out.append(f"Generated: 2026-04-23  |  wkmigrate SHA: cfb49e6\n\n")
+    out.append("## X-1 Expression Coverage (if_condition)\n")
+    out.append("| Corpus | Resolved | Total | Coverage | Baseline | Delta | Within +/-5% |\n")
+    out.append("|---|---|---|---|---|---|---|\n")
+    delta_crp = crp_x1 - baseline_x1
+    delta_vc = vc_x1 - baseline_x1
+    out.append(f"| CRP0001 baseline (pinned) | — | — | 0.8317 | 0.8317 | 0.0000 | yes |\n")
+    gate_crp = "yes" if abs(delta_crp) <= 0.05 else "NO (hard-gate flag)"
+    out.append(f"| CRP0001 replay @ cfb49e6 | {crp_context['resolved']} | {crp_context['total']} | {crp_x1:.4f} | 0.8317 | {delta_crp:+.4f} | {gate_crp} |\n")
+    gate_vc = "yes" if abs(delta_vc) <= 0.05 else "NO (expected: different corpus)"
+    out.append(f"| Vista Cliente @ cfb49e6 | {vc_context['resolved']} | {vc_context['total']} | {vc_x1:.4f} | 0.8317 | {delta_vc:+.4f} | {gate_vc} |\n\n")
+
+    out.append("## X-6 Per-canonical-category Coverage (if_condition, target >=0.70)\n")
+    out.append("| Category | CRP0001 resolved/total | CRP0001 cov | VC resolved/total | VC cov | Delta | VC Pass |\n")
+    out.append("|---|---|---|---|---|---|---|\n")
+    all_cats = sorted(set(vc_cat.keys()) | set(crp_cat.keys()))
+    per_cat_table = []
+    for cat in all_cats:
+        cc = crp_cat.get(cat)
+        vc = vc_cat.get(cat)
+        ccov = _coverage(cc) if cc else None
+        vcov = _coverage(vc) if vc else None
+        crp_s = f"{cc['resolved']}/{cc['total']}" if cc else "—"
+        vc_s = f"{vc['resolved']}/{vc['total']}" if vc else "—"
+        crp_c = f"{ccov:.4f}" if ccov is not None else "—"
+        vc_c = f"{vcov:.4f}" if vcov is not None else "—"
+        if ccov is not None and vcov is not None:
+            dl = vcov - ccov
+            dl_s = f"{dl:+.4f}"
+        else:
+            dl_s = "—"
+        vc_pass = "yes" if (vcov is not None and vcov >= 0.70) else ("—" if vcov is None else "NO")
+        out.append(f"| {cat} | {crp_s} | {crp_c} | {vc_s} | {vc_c} | {dl_s} | {vc_pass} |\n")
+        per_cat_table.append({"cat": cat, "crp_cov": ccov, "vc_cov": vcov})
+    out.append("\n")
+
+    out.append("## X-2 Semantic Equivalence (if_condition)\n")
+    out.append("| Corpus | Status |\n|---|---|\n")
+    out.append("| CRP0001 | BLOCKED — DATABRICKS_HOST unset; judge-dependent |\n")
+    out.append("| Vista Cliente | BLOCKED — DATABRICKS_HOST unset + `expected_python` null (VC lacks oracle) |\n\n")
+
+    out.append("## Secondary: VC all-contexts resolution\n")
+    out.append("| Context | Resolved | Total | Coverage | not_translatable |\n")
+    out.append("|---|---|---|---|---|\n")
+    for ctx, cell in sorted(vc_all_ctx.items()):
+        cov = _coverage(cell)
+        out.append(f"| {ctx} | {cell.get('resolved',0)} | {cell.get('total',0)} | {cov:.4f} | {cell.get('not_translatable_count',0)} |\n")
+
+    print("".join(out))
+
+    # also dump a JSON summary
+    summary_path = RESULTS_DIR / "step7-kpi-summary-2026-04-23.json"
+    summary_path.write_text(json.dumps({
+        "wkmigrate_sha": "cfb49e6",
+        "baseline_x1": baseline_x1,
+        "crp0001_replay_x1": crp_x1,
+        "vista_cliente_x1": vc_x1,
+        "delta_crp_vs_baseline": delta_crp,
+        "delta_vc_vs_baseline": delta_vc,
+        "crp_within_5pct": abs(delta_crp) <= 0.05,
+        "x6_per_category": {cat: {"crp_cov": c.get("crp_cov"), "vc_cov": c.get("vc_cov")} for cat, c in zip([x["cat"] for x in per_cat_table], per_cat_table)},
+        "vc_all_contexts": {ctx: _coverage(cell) for ctx, cell in vc_all_ctx.items()},
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_step7_kpis.py
+++ b/scripts/compute_step7_kpis.py
@@ -10,7 +10,6 @@ Usage:
 from __future__ import annotations
 
 import json
-from collections import defaultdict
 from pathlib import Path
 
 RESULTS_DIR = Path("dev/results/step-7-vista-cliente")
@@ -58,13 +57,13 @@ def main():
 
     out = []
     out.append("# Step 7 — Vista Cliente Sweep KPI Table\n")
-    out.append(f"Generated: 2026-04-23  |  wkmigrate SHA: cfb49e6\n\n")
+    out.append("Generated: 2026-04-23  |  wkmigrate SHA: cfb49e6\n\n")
     out.append("## X-1 Expression Coverage (if_condition)\n")
     out.append("| Corpus | Resolved | Total | Coverage | Baseline | Delta | Within +/-5% |\n")
     out.append("|---|---|---|---|---|---|---|\n")
     delta_crp = crp_x1 - baseline_x1
     delta_vc = vc_x1 - baseline_x1
-    out.append(f"| CRP0001 baseline (pinned) | — | — | 0.8317 | 0.8317 | 0.0000 | yes |\n")
+    out.append("| CRP0001 baseline (pinned) | — | — | 0.8317 | 0.8317 | 0.0000 | yes |\n")
     gate_crp = "yes" if abs(delta_crp) <= 0.05 else "NO (hard-gate flag)"
     out.append(f"| CRP0001 replay @ cfb49e6 | {crp_context['resolved']} | {crp_context['total']} | {crp_x1:.4f} | 0.8317 | {delta_crp:+.4f} | {gate_crp} |\n")
     gate_vc = "yes" if abs(delta_vc) <= 0.05 else "NO (expected: different corpus)"

--- a/scripts/extract_vista_cliente_expressions.py
+++ b/scripts/extract_vista_cliente_expressions.py
@@ -99,6 +99,9 @@ def _walk_activities(activities, pipeline_name: str, out: list, depth: int = 0, 
         # also traverse ForEach / Switch / Until children
         tp = act.get("typeProperties") or {}
         for child_key in ("activities", "ifTrueActivities", "ifFalseActivities", "defaultActivities"):
+            # Skip ifTrueActivities/ifFalseActivities for IfCondition (already handled above at depth + 1)
+            if act_type == "IfCondition" and child_key in ("ifTrueActivities", "ifFalseActivities"):
+                continue
             if child_key in tp:
                 _walk_activities(tp.get(child_key) or [], pipeline_name, out, depth, path)
         for case in tp.get("cases") or []:

--- a/scripts/extract_vista_cliente_expressions.py
+++ b/scripts/extract_vista_cliente_expressions.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Extract IfCondition expressions from the Vista Cliente ADF corpus and emit
+a stratified golden-set JSON plus a full category histogram.
+
+Usage:
+    python scripts/extract_vista_cliente_expressions.py \
+        --corpus ~/Downloads/DataFactory/pipeline \
+        --out golden_sets/vista_cliente_expressions.json \
+        --hist dev/findings/vista-cliente-category-histogram-2026-04-23.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import random
+import re
+from pathlib import Path
+
+# 9 VC buckets -> canonical categories (keep X-6 reporting stable)
+VC_TO_CANONICAL = {
+    "compound_and": "logical",
+    "compound_or": "logical",
+    "nested_predicate": "logical",
+    "equals_binary": "logical",
+    "contains_intersection_empty": "collection",
+    "concat_string": "string",
+    "variables_ref": "nested",
+    "bare_activity_output": "nested",
+    "pipeline_param_ref": "nested",
+}
+
+# --- classification helpers -------------------------------------------------
+
+def _classify(expr: str, depth: int) -> str:
+    e = expr or ""
+    low = e.lower()
+    has_and = "@and(" in low
+    has_or = "@or(" in low
+    has_equals = "@equals(" in low
+    has_contains = "@contains(" in low or "@intersection(" in low or "@empty(" in low
+    has_concat = "@concat(" in low or "touppers(" in low or "toupper(" in low or "replace(" in low
+    has_vars = "variables(" in low
+    has_pipeline_param = "pipeline().parameters." in low
+    bare_expr = e.strip().startswith("@{") is False and not e.strip().startswith("@")
+    # priority: compound > nested > equals > contains > concat > variable > param > bare
+    if has_and and (has_or or has_equals or has_contains):
+        return "nested_predicate"
+    if has_and:
+        return "compound_and"
+    if has_or:
+        return "compound_or"
+    if depth >= 2:
+        return "nested_predicate"
+    if has_equals:
+        return "equals_binary"
+    if has_contains:
+        return "contains_intersection_empty"
+    if has_concat:
+        return "concat_string"
+    if has_vars:
+        return "variables_ref"
+    if has_pipeline_param:
+        return "pipeline_param_ref"
+    if bare_expr:
+        return "bare_activity_output"
+    # fallback
+    return "bare_activity_output"
+
+
+# --- recursive walk ---------------------------------------------------------
+
+def _walk_activities(activities, pipeline_name: str, out: list, depth: int = 0, parent: str = ""):
+    if not isinstance(activities, list):
+        return
+    for act in activities:
+        if not isinstance(act, dict):
+            continue
+        act_type = act.get("type", "")
+        act_name = act.get("name", "")
+        path = f"{parent}/{act_name}" if parent else act_name
+        if act_type == "IfCondition":
+            tp = act.get("typeProperties") or {}
+            expr_obj = tp.get("expression") or {}
+            expr_val = expr_obj.get("value") if isinstance(expr_obj, dict) else expr_obj
+            if expr_val:
+                vc_cat = _classify(expr_val, depth)
+                out.append({
+                    "pipeline": pipeline_name,
+                    "activity_name": path,
+                    "depth": depth,
+                    "raw_expression": expr_val,
+                    "vc_category": vc_cat,
+                })
+            # recurse
+            _walk_activities(tp.get("ifTrueActivities") or [], pipeline_name, out, depth + 1, path)
+            _walk_activities(tp.get("ifFalseActivities") or [], pipeline_name, out, depth + 1, path)
+        # also traverse ForEach / Switch / Until children
+        tp = act.get("typeProperties") or {}
+        for child_key in ("activities", "ifTrueActivities", "ifFalseActivities", "defaultActivities"):
+            if child_key in tp:
+                _walk_activities(tp.get(child_key) or [], pipeline_name, out, depth, path)
+        for case in tp.get("cases") or []:
+            if isinstance(case, dict):
+                _walk_activities(case.get("activities") or [], pipeline_name, out, depth, path)
+
+
+def _extract_all(corpus_dir: Path) -> list[dict]:
+    records: list[dict] = []
+    for fp in sorted(corpus_dir.glob("*.json")):
+        try:
+            d = json.loads(fp.read_text())
+        except Exception:
+            continue
+        props = d.get("properties") or {}
+        activities = props.get("activities") or d.get("activities") or []
+        _walk_activities(activities, fp.stem, records)
+    return records
+
+
+# --- sampling ---------------------------------------------------------------
+
+def _stratified_sample(records: list[dict], seed: int = 42, total_target: int = 200,
+                       floor: int = 12) -> list[dict]:
+    from collections import defaultdict
+    buckets: dict[str, list] = defaultdict(list)
+    for r in records:
+        buckets[r["vc_category"]].append(r)
+
+    rng = random.Random(seed)
+    for vals in buckets.values():
+        rng.shuffle(vals)
+
+    # First: take floor from each bucket (or all if smaller)
+    out = []
+    for vc_cat, vals in buckets.items():
+        take = min(floor, len(vals))
+        out.extend(vals[:take])
+
+    # If under target, fill proportionally from remaining
+    remaining = {k: v[min(floor, len(v)):] for k, v in buckets.items()}
+    while len(out) < total_target:
+        added = 0
+        # proportional top-up by bucket size
+        for vc_cat, vals in sorted(remaining.items(), key=lambda kv: -len(kv[1])):
+            if len(out) >= total_target:
+                break
+            if vals:
+                out.append(vals.pop(0))
+                added += 1
+        if added == 0:
+            break  # exhausted
+    return out
+
+
+# --- main -------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--hist", required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--total", type=int, default=200)
+    ap.add_argument("--floor", type=int, default=12)
+    args = ap.parse_args()
+
+    corpus = Path(os.path.expanduser(args.corpus))
+    records = _extract_all(corpus)
+    from collections import Counter
+    hist = Counter(r["vc_category"] for r in records)
+    total_raw = len(records)
+
+    hist_payload = {
+        "corpus_dir": str(corpus),
+        "total_if_condition_expressions": total_raw,
+        "per_vc_category": dict(hist),
+        "per_canonical_category": dict(Counter(VC_TO_CANONICAL[r["vc_category"]] for r in records)),
+        "pipelines_seen": len({r["pipeline"] for r in records}),
+    }
+    Path(args.hist).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.hist).write_text(json.dumps(hist_payload, indent=2))
+
+    # Filter out empty expressions
+    records = [r for r in records if r["raw_expression"] and str(r["raw_expression"]).strip()]
+
+    sample = _stratified_sample(records, seed=args.seed, total_target=args.total, floor=args.floor)
+
+    expressions = []
+    for r in sample:
+        vc_cat = r["vc_category"]
+        expressions.append({
+            "adf_expression": r["raw_expression"],
+            "category": VC_TO_CANONICAL[vc_cat],
+            "vc_category": vc_cat,
+            "expected_python": None,
+            "source": {
+                "pipeline": r["pipeline"],
+                "activity_name": r["activity_name"],
+                "depth": r["depth"],
+            },
+        })
+
+    out_payload = {
+        "count": len(expressions),
+        "origin": "vista_cliente_if_condition_sweep_2026_04_23",
+        "corpus": str(corpus),
+        "sampling": {
+            "seed": args.seed,
+            "floor_per_vc_category": args.floor,
+            "total_target": args.total,
+            "strategy": "stratified_by_vc_category_with_floor_then_proportional_fill",
+        },
+        "vc_to_canonical_mapping": VC_TO_CANONICAL,
+        "expressions": expressions,
+    }
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out_payload, indent=2))
+
+    print(f"wrote {args.out} (count={len(expressions)})")
+    print(f"wrote {args.hist} (raw_total={total_raw})")
+    print(f"per-vc_category histogram: {dict(hist)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_vista_cliente_expressions.py
+++ b/scripts/extract_vista_cliente_expressions.py
@@ -40,7 +40,7 @@ def _classify(expr: str, depth: int) -> str:
     has_or = "@or(" in low
     has_equals = "@equals(" in low
     has_contains = "@contains(" in low or "@intersection(" in low or "@empty(" in low
-    has_concat = "@concat(" in low or "touppers(" in low or "toupper(" in low or "replace(" in low
+    has_concat = "@concat(" in low or "toupper(" in low or "replace(" in low
     has_vars = "variables(" in low
     has_pipeline_param = "pipeline().parameters." in low
     bare_expr = e.strip().startswith("@{") is False and not e.strip().startswith("@")
@@ -65,8 +65,8 @@ def _classify(expr: str, depth: int) -> str:
         return "pipeline_param_ref"
     if bare_expr:
         return "bare_activity_output"
-    # fallback
-    return "bare_activity_output"
+    # fallback for unrecognized @function(...) expressions
+    return "nested_predicate"
 
 
 # --- recursive walk ---------------------------------------------------------

--- a/scripts/extract_vista_cliente_expressions.py
+++ b/scripts/extract_vista_cliente_expressions.py
@@ -12,10 +12,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import random
-import re
+import sys
 from pathlib import Path
 
 # 9 VC buckets -> canonical categories (keep X-6 reporting stable)
@@ -103,22 +102,31 @@ def _walk_activities(activities, pipeline_name: str, out: list, depth: int = 0, 
             if act_type == "IfCondition" and child_key in ("ifTrueActivities", "ifFalseActivities"):
                 continue
             if child_key in tp:
-                _walk_activities(tp.get(child_key) or [], pipeline_name, out, depth, path)
+                _walk_activities(tp.get(child_key) or [], pipeline_name, out, depth + 1, path)
         for case in tp.get("cases") or []:
             if isinstance(case, dict):
-                _walk_activities(case.get("activities") or [], pipeline_name, out, depth, path)
+                _walk_activities(case.get("activities") or [], pipeline_name, out, depth + 1, path)
 
 
 def _extract_all(corpus_dir: Path) -> list[dict]:
     records: list[dict] = []
+    skipped: list[tuple[str, str]] = []
     for fp in sorted(corpus_dir.glob("*.json")):
         try:
             d = json.loads(fp.read_text())
-        except Exception:
+        except (OSError, json.JSONDecodeError) as exc:
+            # Surface parse/read failures instead of silently dropping — an
+            # extractor whose "coverage" number silently excludes N% of files
+            # is worse than one that's loud about skips.
+            skipped.append((fp.name, f"{type(exc).__name__}: {exc}"))
             continue
         props = d.get("properties") or {}
         activities = props.get("activities") or d.get("activities") or []
         _walk_activities(activities, fp.stem, records)
+    if skipped:
+        print(f"[warn] skipped {len(skipped)} unreadable/malformed pipeline file(s):", file=sys.stderr)
+        for name, reason in skipped:
+            print(f"  {name}: {reason}", file=sys.stderr)
     return records
 
 
@@ -175,8 +183,10 @@ def main():
     hist = Counter(r["vc_category"] for r in records)
     total_raw = len(records)
 
+    # Log only the basename of the corpus dir — the full path may leak a
+    # machine-local /Users/... layout in committed artifacts.
     hist_payload = {
-        "corpus_dir": str(corpus),
+        "corpus_dir": corpus.name,
         "total_if_condition_expressions": total_raw,
         "per_vc_category": dict(hist),
         "per_canonical_category": dict(Counter(VC_TO_CANONICAL[r["vc_category"]] for r in records)),


### PR DESCRIPTION
## Summary

- Builds stratified golden set `golden_sets/vista_cliente_expressions.json` (200 expressions sampled from 212 VC IfCondition activities across 119 pipelines) with an extractor script committed for reproducibility.
- Runs `lmv sweep-activity-contexts` against Vista Cliente at wkmigrate SHA `cfb49e6` (post-Step-1 CRP-11 wrapper emitter + post-Step-3 trigger normalization).
- CRP0001 cross-regression replay at the same SHA.
- Produces session ledger + findings report. No wkmigrate code touched.

## X-series KPI results

| KPI | Target | CRP0001 baseline (pre-Step-1) | CRP0001 replay @ cfb49e6 | Vista Cliente @ cfb49e6 |
|---|---|---|---|---|
| X-1 if_condition coverage | ≥ 0.80 | 0.8317 | **1.0000** (208/208) | **1.0000** (200/200) |
| X-6 logical | ≥ 0.70 | 1.0000 | 1.0000 | **1.0000** |
| X-6 nested | ≥ 0.70 | 1.0000 | 1.0000 | **1.0000** |

**CRP0001 Δ from baseline = +0.1683.** The `±5% hard-gate` tripped in the positive direction — this is the Step 1 CRP-11 wrapper emitter delivering on its promise, not a regression. Re-pin baseline to `cfb49e6`.

**X-2 (semantic_equivalence)**: BLOCKED for both corpora — requires `DATABRICKS_HOST`/`DATABRICKS_TOKEN` (judge) and Vista Cliente has no `expected_python` oracle. Mitigation path in the findings report.

## Vista Cliente corpus characterization (bonus)

212 raw IfCondition activities collapse to **30 unique expression templates**. Per-category distribution:

| Category | Count |
|---|---|
| `pipeline_param_ref` | 149 |
| `variables_ref` | 24 |
| `compound_and` | 14 |
| `equals_binary` | 6 |
| `compound_or` | 5 |
| `bare_activity_output` | 2 |
| `nested_predicate` / `contains_intersection_empty` / `concat_string` | 0 |

VC IfCondition usage is narrower and more template-heavy than CRP0001.

## Candidate wkmigrate issues surfaced (not filed here)

1. **HIGH** — `ForEach` activity from lmv synthetic wrapper emits placeholder (200/200 in `for_each` context). Suggests wkmigrate translator doesn't recognize the lmv-generated `ForEach` JSON shape.
2. **MED** — Lookup translator adoption gap (CRP-28) still present at `cfb49e6`. 200/200 Lookup pipelines emit `not_translatable`.
3. **MED** — `variables()` inside compound predicate inside ForEach emits best-effort `taskValues.get` that may fail at runtime (producer resolution in SetVariable-inside-ForEach).

## Files

| Path | Purpose |
|---|---|
| `dev/plan-lmv-step-7-vista-cliente-sweep.md` | Plan (summarized from agent plan file; Google Doc fetch 403'd) |
| `golden_sets/vista_cliente_expressions.json` | 200 stratified expressions |
| `scripts/extract_vista_cliente_expressions.py` | Extractor for reproducibility |
| `scripts/compute_step7_kpis.py` | KPI aggregator |
| `dev/results/step-7-vista-cliente/*.json` | Sweep outputs |
| `dev/autodev-sessions/LMV-AUTODEV-STEP-7-2026-04-23.md` | Session ledger |
| `dev/reports/step-7-vista-cliente-findings-2026-04-23.md` | Findings report |
| `dev/findings/vista-cliente-category-histogram-2026-04-23.json` | Full unsampled category histogram |

## Test plan

- [x] `uv run lmv sweep-activity-contexts --golden-set golden_sets/vista_cliente_expressions.json --contexts if_condition` — 200/200 resolved
- [x] CRP0001 replay at same SHA — 208/208 resolved
- [x] Hard-gate check: CRP0001 Δ flagged (positive direction, not aborting)
- [x] L-series gates green (no wkmigrate or lmv src changes, so GR/LR gates N/A for new code)
- [ ] X-2 judge-scored pass — deferred pending `DATABRICKS_HOST` wiring

## Follow-ups

1. Re-pin CRP0001 X-1 baseline from 0.8317 → 1.0000 (or whatever measures clean post-Step-1) in `dev/meta-kpis/wkmigrate-issue-27-meta-kpis.md`.
2. Build `lmv batch-expressions` primitive (L-8 backlog) so X-2 is first-class.
3. File the 3 wkmigrate issues listed above against `MiguelPeralvo/wkmigrate` with repro from the findings report.

This pull request and its description were written by Isaac.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are additive (scripts, golden set, and generated sweep/KPI artifacts) with no modifications to `src/` or `tests/` execution paths.
> 
> **Overview**
> Adds Step 7 Vista Cliente semantic-validation sweep deliverables: a new Vista Cliente IfCondition golden set (stratified 200-sample) plus an extractor (`scripts/extract_vista_cliente_expressions.py`) and KPI aggregator (`scripts/compute_step7_kpis.py`) to reproduce X-series reporting.
> 
> Commits the run outputs and documentation (plan, session ledger, findings report, sweep JSONs, KPI summary, and batch stderr) including a CRP0001 replay at `wkmigrate` SHA `cfb49e6` and notes that the historical X-1 baseline appears stale and that the `for_each` synthetic context yields 100% placeholder substitution in the secondary sweep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b542a3de6873324accaadce7b9fdfbda70eb33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->